### PR TITLE
Start factoring out srr tests

### DIFF
--- a/inst/srr_template_nonspatial_yardstick.R
+++ b/inst/srr_template_nonspatial_yardstick.R
@@ -1,185 +1,180 @@
-test_that("srr: expected failures for {{{name}}}", {
+test_that("srr: {{{name}}} errors if truth and estimate are different lengths", {
   # Note that this test isn't applicable to data-frame input, which enforces
   # constant column lengths
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     {{{name}}}_vec(1:5, 1:4),
     error = TRUE
   )
-
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     {{{name}}}_vec(1:4, 1:5),
     error = TRUE
   )
+})
 
+test_that("srr: {{{name}}} errors if truth and estimate aren't numeric", {
   char_df <- tibble::tibble(x = 1:5, y = letters[1:5])
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     {{{name}}}(char_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     {{{name}}}(char_df, y, x),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     {{{name}}}_vec(as.character(1:5), 1:4),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     {{{name}}}_vec(1:5, as.character(1:4)),
     error = TRUE
   )
+})
 
+test_that("srr: {{{name}}} errors if truth and estimate are list columns", {
   list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     {{{name}}}(list_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     {{{name}}}(list_df, y, x),
     error = TRUE
   )
+})
 
-  #' @srrstats {G2.13} Missing data is properly handled
-  #' @srrstats {G2.15} Missingness is checked
-  #' @srrstats {G2.14} Users can specify behavior with NA results
-  #' @srrstats {G2.16} NaN is properly handled
+test_that("srr: {{{name}}} errors if truth and estimate are list columns", {
+  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
+  expect_snapshot(
+    {{{name}}}(list_df, x, y),
+    error = TRUE
+  )
+
+  expect_snapshot(
+    {{{name}}}(list_df, y, x),
+    error = TRUE
+  )
+})
+
+test_that("srr: {{{name}}} removes NaN and NA when na_rm = TRUE", {
+
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
-  #' Users can remove NA:
+
   expect_snapshot(
     round({{{name}}}(missing_df, x, y)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round({{{name}}}(missing_df, y, x)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round({{{name}}}_vec(missing_df$y, missing_df$x), 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round({{{name}}}_vec(missing_df$x, missing_df$y), 15),
   )
+})
 
-  #' @srrstats {G2.14b} Users can ignore NA:
+test_that("srr: {{{name}}} returns NA when na_rm = FALSE and NA is present", {
+
+  missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
+
   expect_identical(
     {{{name}}}(missing_df, y, x, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     {{{name}}}(missing_df, x, y, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     {{{name}}}_vec(missing_df$y, missing_df$x, na_rm = FALSE),
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     {{{name}}}_vec(missing_df$x, missing_df$y, na_rm = FALSE),
     NA_real_
   )
 
-  # Edge condition tests: Zero-length data:
+})
+
+test_that("srr: {{{name}}} errors on zero-length data", {
+
   expect_snapshot(
     {{{name}}}_vec(numeric(), numeric()),
     error = TRUE
   )
 
   empty_df <- tibble::tibble(x = numeric(), y = numeric())
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     {{{name}}}(empty_df, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     {{{name}}}(empty_df, y, x),
     error = TRUE
   )
+})
 
-  # Edge condition tests: All-NA:
+test_that("srr: {{{name}}} errors on all-NA data", {
+
   expect_snapshot(
     {{{name}}}_vec(rep(NA_real_, 4), 4:1),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     {{{name}}}_vec(1:4, rep(NA_real_, 4)),
     error = TRUE
   )
 
   all_na <- tibble::tibble(x = rep(NA_real_, 4), y = 1:4)
-  # Edge condition tests: All-NA:
   expect_snapshot(
     {{{name}}}(all_na, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     {{{name}}}(all_na, y, x),
     error = TRUE
   )
 
-  # Edge condition tests: All-identical:
+  expect_snapshot(
+    {{{name}}}_vec(1:4, 1:4)
+  )
+
+})
+
+
+test_that("srr: {{{name}}} works with all identical data", {
+
+  all_identical <- tibble::tibble(x = 1:4, y = 1:4)
+  expect_snapshot(
+    {{{name}}}(all_identical, x, y)
+  )
+
   expect_snapshot(
     {{{name}}}_vec(1:4, 1:4)
   )
 
   all_identical <- tibble::tibble(x = 1:4, y = 1:4)
-  # Edge condition tests: All-identical:
   expect_snapshot(
     {{{name}}}(all_identical, x, y)
   )
 
 })
 
-test_that("other generic srr standards", {
+test_that("srr: {{{name}}} results don't change with trivial noise", {
   skip_if_not_installed("withr")
   x <- c(6, 8, 9, 10, 11, 14)
   y <- c(2, 3, 5, 5, 6, 8)
@@ -187,31 +182,34 @@ test_that("other generic srr standards", {
   noised_x <- x + rnorm(x, .Machine$double.eps, .Machine$double.eps)
   noised_df <- tibble::tibble(x = noised_x, y = y)
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     {{{name}}}(noised_df, x, y),
     {{{name}}}(df, x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     {{{name}}}(noised_df, y, x),
     {{{name}}}(df, y, x)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     {{{name}}}_vec(noised_x, y),
     {{{name}}}_vec(x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     {{{name}}}_vec(y, noised_x),
     {{{name}}}_vec(y, x)
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
+})
+
+test_that("srr: {{{name}}} results don't change with different seeds", {
+  skip_if_not_installed("withr")
+  x <- c(6, 8, 9, 10, 11, 14)
+  y <- c(2, 3, 5, 5, 6, 8)
+  df <- tibble::tibble(x = x, y = y)
+
   expect_equal(
     withr::with_seed(
       123,
@@ -223,7 +221,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -235,7 +232,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -247,7 +243,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,

--- a/inst/srr_template_nonspatial_yardstick.R
+++ b/inst/srr_template_nonspatial_yardstick.R
@@ -47,19 +47,6 @@ test_that("srr: {{{name}}} errors if truth and estimate are list columns", {
   )
 })
 
-test_that("srr: {{{name}}} errors if truth and estimate are list columns", {
-  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  expect_snapshot(
-    {{{name}}}(list_df, x, y),
-    error = TRUE
-  )
-
-  expect_snapshot(
-    {{{name}}}(list_df, y, x),
-    error = TRUE
-  )
-})
-
 test_that("srr: {{{name}}} removes NaN and NA when na_rm = TRUE", {
 
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))

--- a/tests/testthat/_snaps/srr-ww_agreement_coefficient.md
+++ b/tests/testthat/_snaps/srr-ww_agreement_coefficient.md
@@ -1,4 +1,4 @@
-# srr: expected failures for ww_agreement_coefficient
+# srr: ww_agreement_coefficient errors if truth and estimate are different lengths
 
     Code
       ww_agreement_coefficient_vec(1:5, 1:4)
@@ -14,7 +14,7 @@
       Error in `yardstick_vec()`:
       ! Length of `truth` (4) and `estimate` (5) must match.
 
----
+# srr: ww_agreement_coefficient errors if truth and estimate aren't numeric
 
     Code
       ww_agreement_coefficient(char_df, x, y)
@@ -50,7 +50,7 @@
       Error in `yardstick_vec()`:
       ! `estimate` must be numeric.
 
----
+# srr: ww_agreement_coefficient errors if truth and estimate are list columns
 
     Code
       ww_agreement_coefficient(list_df, x, y)
@@ -71,6 +71,26 @@
       ! `truth` must be numeric.
 
 ---
+
+    Code
+      ww_agreement_coefficient(list_df, x, y)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `estimate` must be numeric.
+
+---
+
+    Code
+      ww_agreement_coefficient(list_df, y, x)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `truth` must be numeric.
+
+# srr: ww_agreement_coefficient removes NaN and NA when na_rm = TRUE
 
     Code
       round(ww_agreement_coefficient(missing_df, x, y)$.estimate, 15)
@@ -98,7 +118,7 @@
     Output
       [1] 1
 
----
+# srr: ww_agreement_coefficient errors on zero-length data
 
     Code
       ww_agreement_coefficient_vec(numeric(), numeric())
@@ -126,7 +146,7 @@
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
 
----
+# srr: ww_agreement_coefficient errors on all-NA data
 
     Code
       ww_agreement_coefficient_vec(rep(NA_real_, 4), 4:1)
@@ -161,6 +181,23 @@
       i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
+
+---
+
+    Code
+      ww_agreement_coefficient_vec(1:4, 1:4)
+    Output
+      [1] 1
+
+# srr: ww_agreement_coefficient works with all identical data
+
+    Code
+      ww_agreement_coefficient(all_identical, x, y)
+    Output
+      # A tibble: 1 x 3
+        .metric               .estimator .estimate
+        <chr>                 <chr>          <dbl>
+      1 agreement_coefficient standard           1
 
 ---
 

--- a/tests/testthat/_snaps/srr-ww_agreement_coefficient.md
+++ b/tests/testthat/_snaps/srr-ww_agreement_coefficient.md
@@ -70,26 +70,6 @@
       Caused by error in `yardstick_vec()`:
       ! `truth` must be numeric.
 
----
-
-    Code
-      ww_agreement_coefficient(list_df, x, y)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `estimate` must be numeric.
-
----
-
-    Code
-      ww_agreement_coefficient(list_df, y, x)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `truth` must be numeric.
-
 # srr: ww_agreement_coefficient removes NaN and NA when na_rm = TRUE
 
     Code

--- a/tests/testthat/_snaps/srr-ww_systematic_agreement_coefficient.md
+++ b/tests/testthat/_snaps/srr-ww_systematic_agreement_coefficient.md
@@ -70,26 +70,6 @@
       Caused by error in `yardstick_vec()`:
       ! `truth` must be numeric.
 
----
-
-    Code
-      ww_systematic_agreement_coefficient(list_df, x, y)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `estimate` must be numeric.
-
----
-
-    Code
-      ww_systematic_agreement_coefficient(list_df, y, x)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `truth` must be numeric.
-
 # srr: ww_systematic_agreement_coefficient removes NaN and NA when na_rm = TRUE
 
     Code

--- a/tests/testthat/_snaps/srr-ww_systematic_agreement_coefficient.md
+++ b/tests/testthat/_snaps/srr-ww_systematic_agreement_coefficient.md
@@ -1,4 +1,4 @@
-# srr: expected failures for ww_systematic_agreement_coefficient
+# srr: ww_systematic_agreement_coefficient errors if truth and estimate are different lengths
 
     Code
       ww_systematic_agreement_coefficient_vec(1:5, 1:4)
@@ -14,7 +14,7 @@
       Error in `yardstick_vec()`:
       ! Length of `truth` (4) and `estimate` (5) must match.
 
----
+# srr: ww_systematic_agreement_coefficient errors if truth and estimate aren't numeric
 
     Code
       ww_systematic_agreement_coefficient(char_df, x, y)
@@ -50,7 +50,7 @@
       Error in `yardstick_vec()`:
       ! `estimate` must be numeric.
 
----
+# srr: ww_systematic_agreement_coefficient errors if truth and estimate are list columns
 
     Code
       ww_systematic_agreement_coefficient(list_df, x, y)
@@ -71,6 +71,26 @@
       ! `truth` must be numeric.
 
 ---
+
+    Code
+      ww_systematic_agreement_coefficient(list_df, x, y)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `estimate` must be numeric.
+
+---
+
+    Code
+      ww_systematic_agreement_coefficient(list_df, y, x)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `truth` must be numeric.
+
+# srr: ww_systematic_agreement_coefficient removes NaN and NA when na_rm = TRUE
 
     Code
       round(ww_systematic_agreement_coefficient(missing_df, x, y)$.estimate, 15)
@@ -98,7 +118,7 @@
     Output
       [1] 1
 
----
+# srr: ww_systematic_agreement_coefficient errors on zero-length data
 
     Code
       ww_systematic_agreement_coefficient_vec(numeric(), numeric())
@@ -126,7 +146,7 @@
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
 
----
+# srr: ww_systematic_agreement_coefficient errors on all-NA data
 
     Code
       ww_systematic_agreement_coefficient_vec(rep(NA_real_, 4), 4:1)
@@ -161,6 +181,23 @@
       i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
+
+---
+
+    Code
+      ww_systematic_agreement_coefficient_vec(1:4, 1:4)
+    Output
+      [1] 1
+
+# srr: ww_systematic_agreement_coefficient works with all identical data
+
+    Code
+      ww_systematic_agreement_coefficient(all_identical, x, y)
+    Output
+      # A tibble: 1 x 3
+        .metric                          .estimator .estimate
+        <chr>                            <chr>          <dbl>
+      1 systematic_agreement_coefficient standard           1
 
 ---
 

--- a/tests/testthat/_snaps/srr-ww_systematic_mpd.md
+++ b/tests/testthat/_snaps/srr-ww_systematic_mpd.md
@@ -70,26 +70,6 @@
       Caused by error in `yardstick_vec()`:
       ! `truth` must be numeric.
 
----
-
-    Code
-      ww_systematic_mpd(list_df, x, y)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `estimate` must be numeric.
-
----
-
-    Code
-      ww_systematic_mpd(list_df, y, x)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `truth` must be numeric.
-
 # srr: ww_systematic_mpd removes NaN and NA when na_rm = TRUE
 
     Code

--- a/tests/testthat/_snaps/srr-ww_systematic_mpd.md
+++ b/tests/testthat/_snaps/srr-ww_systematic_mpd.md
@@ -1,4 +1,4 @@
-# srr: expected failures for ww_systematic_mpd
+# srr: ww_systematic_mpd errors if truth and estimate are different lengths
 
     Code
       ww_systematic_mpd_vec(1:5, 1:4)
@@ -14,7 +14,7 @@
       Error in `yardstick_vec()`:
       ! Length of `truth` (4) and `estimate` (5) must match.
 
----
+# srr: ww_systematic_mpd errors if truth and estimate aren't numeric
 
     Code
       ww_systematic_mpd(char_df, x, y)
@@ -50,7 +50,7 @@
       Error in `yardstick_vec()`:
       ! `estimate` must be numeric.
 
----
+# srr: ww_systematic_mpd errors if truth and estimate are list columns
 
     Code
       ww_systematic_mpd(list_df, x, y)
@@ -71,6 +71,26 @@
       ! `truth` must be numeric.
 
 ---
+
+    Code
+      ww_systematic_mpd(list_df, x, y)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `estimate` must be numeric.
+
+---
+
+    Code
+      ww_systematic_mpd(list_df, y, x)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `truth` must be numeric.
+
+# srr: ww_systematic_mpd removes NaN and NA when na_rm = TRUE
 
     Code
       round(ww_systematic_mpd(missing_df, x, y)$.estimate, 15)
@@ -98,7 +118,7 @@
     Output
       [1] 0
 
----
+# srr: ww_systematic_mpd errors on zero-length data
 
     Code
       ww_systematic_mpd_vec(numeric(), numeric())
@@ -126,7 +146,7 @@
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
 
----
+# srr: ww_systematic_mpd errors on all-NA data
 
     Code
       ww_systematic_mpd_vec(rep(NA_real_, 4), 4:1)
@@ -161,6 +181,23 @@
       i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
+
+---
+
+    Code
+      ww_systematic_mpd_vec(1:4, 1:4)
+    Output
+      [1] 0
+
+# srr: ww_systematic_mpd works with all identical data
+
+    Code
+      ww_systematic_mpd(all_identical, x, y)
+    Output
+      # A tibble: 1 x 3
+        .metric        .estimator .estimate
+        <chr>          <chr>          <dbl>
+      1 systematic_mpd standard           0
 
 ---
 

--- a/tests/testthat/_snaps/srr-ww_systematic_mse.md
+++ b/tests/testthat/_snaps/srr-ww_systematic_mse.md
@@ -70,26 +70,6 @@
       Caused by error in `yardstick_vec()`:
       ! `truth` must be numeric.
 
----
-
-    Code
-      ww_systematic_mse(list_df, x, y)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `estimate` must be numeric.
-
----
-
-    Code
-      ww_systematic_mse(list_df, y, x)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `truth` must be numeric.
-
 # srr: ww_systematic_mse removes NaN and NA when na_rm = TRUE
 
     Code

--- a/tests/testthat/_snaps/srr-ww_systematic_mse.md
+++ b/tests/testthat/_snaps/srr-ww_systematic_mse.md
@@ -1,4 +1,4 @@
-# srr: expected failures for ww_systematic_mse
+# srr: ww_systematic_mse errors if truth and estimate are different lengths
 
     Code
       ww_systematic_mse_vec(1:5, 1:4)
@@ -14,7 +14,7 @@
       Error in `yardstick_vec()`:
       ! Length of `truth` (4) and `estimate` (5) must match.
 
----
+# srr: ww_systematic_mse errors if truth and estimate aren't numeric
 
     Code
       ww_systematic_mse(char_df, x, y)
@@ -50,7 +50,7 @@
       Error in `yardstick_vec()`:
       ! `estimate` must be numeric.
 
----
+# srr: ww_systematic_mse errors if truth and estimate are list columns
 
     Code
       ww_systematic_mse(list_df, x, y)
@@ -71,6 +71,26 @@
       ! `truth` must be numeric.
 
 ---
+
+    Code
+      ww_systematic_mse(list_df, x, y)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `estimate` must be numeric.
+
+---
+
+    Code
+      ww_systematic_mse(list_df, y, x)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `truth` must be numeric.
+
+# srr: ww_systematic_mse removes NaN and NA when na_rm = TRUE
 
     Code
       round(ww_systematic_mse(missing_df, x, y)$.estimate, 15)
@@ -98,7 +118,7 @@
     Output
       [1] 0
 
----
+# srr: ww_systematic_mse errors on zero-length data
 
     Code
       ww_systematic_mse_vec(numeric(), numeric())
@@ -126,7 +146,7 @@
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
 
----
+# srr: ww_systematic_mse errors on all-NA data
 
     Code
       ww_systematic_mse_vec(rep(NA_real_, 4), 4:1)
@@ -161,6 +181,23 @@
       i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
+
+---
+
+    Code
+      ww_systematic_mse_vec(1:4, 1:4)
+    Output
+      [1] 0
+
+# srr: ww_systematic_mse works with all identical data
+
+    Code
+      ww_systematic_mse(all_identical, x, y)
+    Output
+      # A tibble: 1 x 3
+        .metric        .estimator .estimate
+        <chr>          <chr>          <dbl>
+      1 systematic_mse standard           0
 
 ---
 

--- a/tests/testthat/_snaps/srr-ww_systematic_rmpd.md
+++ b/tests/testthat/_snaps/srr-ww_systematic_rmpd.md
@@ -1,4 +1,4 @@
-# srr: expected failures for ww_systematic_rmpd
+# srr: ww_systematic_rmpd errors if truth and estimate are different lengths
 
     Code
       ww_systematic_rmpd_vec(1:5, 1:4)
@@ -14,7 +14,7 @@
       Error in `yardstick_vec()`:
       ! Length of `truth` (4) and `estimate` (5) must match.
 
----
+# srr: ww_systematic_rmpd errors if truth and estimate aren't numeric
 
     Code
       ww_systematic_rmpd(char_df, x, y)
@@ -50,7 +50,7 @@
       Error in `yardstick_vec()`:
       ! `estimate` must be numeric.
 
----
+# srr: ww_systematic_rmpd errors if truth and estimate are list columns
 
     Code
       ww_systematic_rmpd(list_df, x, y)
@@ -71,6 +71,26 @@
       ! `truth` must be numeric.
 
 ---
+
+    Code
+      ww_systematic_rmpd(list_df, x, y)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `estimate` must be numeric.
+
+---
+
+    Code
+      ww_systematic_rmpd(list_df, y, x)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `truth` must be numeric.
+
+# srr: ww_systematic_rmpd removes NaN and NA when na_rm = TRUE
 
     Code
       round(ww_systematic_rmpd(missing_df, x, y)$.estimate, 15)
@@ -98,7 +118,7 @@
     Output
       [1] 0
 
----
+# srr: ww_systematic_rmpd errors on zero-length data
 
     Code
       ww_systematic_rmpd_vec(numeric(), numeric())
@@ -126,7 +146,7 @@
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
 
----
+# srr: ww_systematic_rmpd errors on all-NA data
 
     Code
       ww_systematic_rmpd_vec(rep(NA_real_, 4), 4:1)
@@ -161,6 +181,23 @@
       i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
+
+---
+
+    Code
+      ww_systematic_rmpd_vec(1:4, 1:4)
+    Output
+      [1] 0
+
+# srr: ww_systematic_rmpd works with all identical data
+
+    Code
+      ww_systematic_rmpd(all_identical, x, y)
+    Output
+      # A tibble: 1 x 3
+        .metric         .estimator .estimate
+        <chr>           <chr>          <dbl>
+      1 systematic_rmpd standard           0
 
 ---
 

--- a/tests/testthat/_snaps/srr-ww_systematic_rmpd.md
+++ b/tests/testthat/_snaps/srr-ww_systematic_rmpd.md
@@ -70,26 +70,6 @@
       Caused by error in `yardstick_vec()`:
       ! `truth` must be numeric.
 
----
-
-    Code
-      ww_systematic_rmpd(list_df, x, y)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `estimate` must be numeric.
-
----
-
-    Code
-      ww_systematic_rmpd(list_df, y, x)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `truth` must be numeric.
-
 # srr: ww_systematic_rmpd removes NaN and NA when na_rm = TRUE
 
     Code

--- a/tests/testthat/_snaps/srr-ww_systematic_rmse.md
+++ b/tests/testthat/_snaps/srr-ww_systematic_rmse.md
@@ -1,4 +1,4 @@
-# srr: expected failures for ww_systematic_rmse
+# srr: ww_systematic_rmse errors if truth and estimate are different lengths
 
     Code
       ww_systematic_rmse_vec(1:5, 1:4)
@@ -14,7 +14,7 @@
       Error in `yardstick_vec()`:
       ! Length of `truth` (4) and `estimate` (5) must match.
 
----
+# srr: ww_systematic_rmse errors if truth and estimate aren't numeric
 
     Code
       ww_systematic_rmse(char_df, x, y)
@@ -50,7 +50,7 @@
       Error in `yardstick_vec()`:
       ! `estimate` must be numeric.
 
----
+# srr: ww_systematic_rmse errors if truth and estimate are list columns
 
     Code
       ww_systematic_rmse(list_df, x, y)
@@ -71,6 +71,26 @@
       ! `truth` must be numeric.
 
 ---
+
+    Code
+      ww_systematic_rmse(list_df, x, y)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `estimate` must be numeric.
+
+---
+
+    Code
+      ww_systematic_rmse(list_df, y, x)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `truth` must be numeric.
+
+# srr: ww_systematic_rmse removes NaN and NA when na_rm = TRUE
 
     Code
       round(ww_systematic_rmse(missing_df, x, y)$.estimate, 15)
@@ -98,7 +118,7 @@
     Output
       [1] 0
 
----
+# srr: ww_systematic_rmse errors on zero-length data
 
     Code
       ww_systematic_rmse_vec(numeric(), numeric())
@@ -126,7 +146,7 @@
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
 
----
+# srr: ww_systematic_rmse errors on all-NA data
 
     Code
       ww_systematic_rmse_vec(rep(NA_real_, 4), 4:1)
@@ -161,6 +181,23 @@
       i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
+
+---
+
+    Code
+      ww_systematic_rmse_vec(1:4, 1:4)
+    Output
+      [1] 0
+
+# srr: ww_systematic_rmse works with all identical data
+
+    Code
+      ww_systematic_rmse(all_identical, x, y)
+    Output
+      # A tibble: 1 x 3
+        .metric         .estimator .estimate
+        <chr>           <chr>          <dbl>
+      1 systematic_rmse standard           0
 
 ---
 

--- a/tests/testthat/_snaps/srr-ww_systematic_rmse.md
+++ b/tests/testthat/_snaps/srr-ww_systematic_rmse.md
@@ -70,26 +70,6 @@
       Caused by error in `yardstick_vec()`:
       ! `truth` must be numeric.
 
----
-
-    Code
-      ww_systematic_rmse(list_df, x, y)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `estimate` must be numeric.
-
----
-
-    Code
-      ww_systematic_rmse(list_df, y, x)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `truth` must be numeric.
-
 # srr: ww_systematic_rmse removes NaN and NA when na_rm = TRUE
 
     Code

--- a/tests/testthat/_snaps/srr-ww_unsystematic_agreement_coefficient.md
+++ b/tests/testthat/_snaps/srr-ww_unsystematic_agreement_coefficient.md
@@ -1,4 +1,4 @@
-# srr: expected failures for ww_unsystematic_agreement_coefficient
+# srr: ww_unsystematic_agreement_coefficient errors if truth and estimate are different lengths
 
     Code
       ww_unsystematic_agreement_coefficient_vec(1:5, 1:4)
@@ -14,7 +14,7 @@
       Error in `yardstick_vec()`:
       ! Length of `truth` (4) and `estimate` (5) must match.
 
----
+# srr: ww_unsystematic_agreement_coefficient errors if truth and estimate aren't numeric
 
     Code
       ww_unsystematic_agreement_coefficient(char_df, x, y)
@@ -50,7 +50,7 @@
       Error in `yardstick_vec()`:
       ! `estimate` must be numeric.
 
----
+# srr: ww_unsystematic_agreement_coefficient errors if truth and estimate are list columns
 
     Code
       ww_unsystematic_agreement_coefficient(list_df, x, y)
@@ -71,6 +71,26 @@
       ! `truth` must be numeric.
 
 ---
+
+    Code
+      ww_unsystematic_agreement_coefficient(list_df, x, y)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `estimate` must be numeric.
+
+---
+
+    Code
+      ww_unsystematic_agreement_coefficient(list_df, y, x)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `truth` must be numeric.
+
+# srr: ww_unsystematic_agreement_coefficient removes NaN and NA when na_rm = TRUE
 
     Code
       round(ww_unsystematic_agreement_coefficient(missing_df, x, y)$.estimate, 15)
@@ -98,7 +118,7 @@
     Output
       [1] 1
 
----
+# srr: ww_unsystematic_agreement_coefficient errors on zero-length data
 
     Code
       ww_unsystematic_agreement_coefficient_vec(numeric(), numeric())
@@ -126,7 +146,7 @@
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
 
----
+# srr: ww_unsystematic_agreement_coefficient errors on all-NA data
 
     Code
       ww_unsystematic_agreement_coefficient_vec(rep(NA_real_, 4), 4:1)
@@ -161,6 +181,23 @@
       i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
+
+---
+
+    Code
+      ww_unsystematic_agreement_coefficient_vec(1:4, 1:4)
+    Output
+      [1] 1
+
+# srr: ww_unsystematic_agreement_coefficient works with all identical data
+
+    Code
+      ww_unsystematic_agreement_coefficient(all_identical, x, y)
+    Output
+      # A tibble: 1 x 3
+        .metric                            .estimator .estimate
+        <chr>                              <chr>          <dbl>
+      1 unsystematic_agreement_coefficient standard           1
 
 ---
 

--- a/tests/testthat/_snaps/srr-ww_unsystematic_agreement_coefficient.md
+++ b/tests/testthat/_snaps/srr-ww_unsystematic_agreement_coefficient.md
@@ -70,26 +70,6 @@
       Caused by error in `yardstick_vec()`:
       ! `truth` must be numeric.
 
----
-
-    Code
-      ww_unsystematic_agreement_coefficient(list_df, x, y)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `estimate` must be numeric.
-
----
-
-    Code
-      ww_unsystematic_agreement_coefficient(list_df, y, x)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `truth` must be numeric.
-
 # srr: ww_unsystematic_agreement_coefficient removes NaN and NA when na_rm = TRUE
 
     Code

--- a/tests/testthat/_snaps/srr-ww_unsystematic_mpd.md
+++ b/tests/testthat/_snaps/srr-ww_unsystematic_mpd.md
@@ -1,4 +1,4 @@
-# srr: expected failures for ww_unsystematic_mpd
+# srr: ww_unsystematic_mpd errors if truth and estimate are different lengths
 
     Code
       ww_unsystematic_mpd_vec(1:5, 1:4)
@@ -14,7 +14,7 @@
       Error in `yardstick_vec()`:
       ! Length of `truth` (4) and `estimate` (5) must match.
 
----
+# srr: ww_unsystematic_mpd errors if truth and estimate aren't numeric
 
     Code
       ww_unsystematic_mpd(char_df, x, y)
@@ -50,7 +50,7 @@
       Error in `yardstick_vec()`:
       ! `estimate` must be numeric.
 
----
+# srr: ww_unsystematic_mpd errors if truth and estimate are list columns
 
     Code
       ww_unsystematic_mpd(list_df, x, y)
@@ -71,6 +71,26 @@
       ! `truth` must be numeric.
 
 ---
+
+    Code
+      ww_unsystematic_mpd(list_df, x, y)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `estimate` must be numeric.
+
+---
+
+    Code
+      ww_unsystematic_mpd(list_df, y, x)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `truth` must be numeric.
+
+# srr: ww_unsystematic_mpd removes NaN and NA when na_rm = TRUE
 
     Code
       round(ww_unsystematic_mpd(missing_df, x, y)$.estimate, 15)
@@ -98,7 +118,7 @@
     Output
       [1] 0
 
----
+# srr: ww_unsystematic_mpd errors on zero-length data
 
     Code
       ww_unsystematic_mpd_vec(numeric(), numeric())
@@ -126,7 +146,7 @@
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
 
----
+# srr: ww_unsystematic_mpd errors on all-NA data
 
     Code
       ww_unsystematic_mpd_vec(rep(NA_real_, 4), 4:1)
@@ -161,6 +181,23 @@
       i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
+
+---
+
+    Code
+      ww_unsystematic_mpd_vec(1:4, 1:4)
+    Output
+      [1] 0
+
+# srr: ww_unsystematic_mpd works with all identical data
+
+    Code
+      ww_unsystematic_mpd(all_identical, x, y)
+    Output
+      # A tibble: 1 x 3
+        .metric          .estimator .estimate
+        <chr>            <chr>          <dbl>
+      1 unsystematic_mpd standard           0
 
 ---
 

--- a/tests/testthat/_snaps/srr-ww_unsystematic_mpd.md
+++ b/tests/testthat/_snaps/srr-ww_unsystematic_mpd.md
@@ -70,26 +70,6 @@
       Caused by error in `yardstick_vec()`:
       ! `truth` must be numeric.
 
----
-
-    Code
-      ww_unsystematic_mpd(list_df, x, y)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `estimate` must be numeric.
-
----
-
-    Code
-      ww_unsystematic_mpd(list_df, y, x)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `truth` must be numeric.
-
 # srr: ww_unsystematic_mpd removes NaN and NA when na_rm = TRUE
 
     Code

--- a/tests/testthat/_snaps/srr-ww_unsystematic_mse.md
+++ b/tests/testthat/_snaps/srr-ww_unsystematic_mse.md
@@ -1,4 +1,4 @@
-# srr: expected failures for ww_unsystematic_mse
+# srr: ww_unsystematic_mse errors if truth and estimate are different lengths
 
     Code
       ww_unsystematic_mse_vec(1:5, 1:4)
@@ -14,7 +14,7 @@
       Error in `yardstick_vec()`:
       ! Length of `truth` (4) and `estimate` (5) must match.
 
----
+# srr: ww_unsystematic_mse errors if truth and estimate aren't numeric
 
     Code
       ww_unsystematic_mse(char_df, x, y)
@@ -50,7 +50,7 @@
       Error in `yardstick_vec()`:
       ! `estimate` must be numeric.
 
----
+# srr: ww_unsystematic_mse errors if truth and estimate are list columns
 
     Code
       ww_unsystematic_mse(list_df, x, y)
@@ -71,6 +71,26 @@
       ! `truth` must be numeric.
 
 ---
+
+    Code
+      ww_unsystematic_mse(list_df, x, y)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `estimate` must be numeric.
+
+---
+
+    Code
+      ww_unsystematic_mse(list_df, y, x)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `truth` must be numeric.
+
+# srr: ww_unsystematic_mse removes NaN and NA when na_rm = TRUE
 
     Code
       round(ww_unsystematic_mse(missing_df, x, y)$.estimate, 15)
@@ -98,7 +118,7 @@
     Output
       [1] 0
 
----
+# srr: ww_unsystematic_mse errors on zero-length data
 
     Code
       ww_unsystematic_mse_vec(numeric(), numeric())
@@ -126,7 +146,7 @@
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
 
----
+# srr: ww_unsystematic_mse errors on all-NA data
 
     Code
       ww_unsystematic_mse_vec(rep(NA_real_, 4), 4:1)
@@ -161,6 +181,23 @@
       i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
+
+---
+
+    Code
+      ww_unsystematic_mse_vec(1:4, 1:4)
+    Output
+      [1] 0
+
+# srr: ww_unsystematic_mse works with all identical data
+
+    Code
+      ww_unsystematic_mse(all_identical, x, y)
+    Output
+      # A tibble: 1 x 3
+        .metric          .estimator .estimate
+        <chr>            <chr>          <dbl>
+      1 unsystematic_mse standard           0
 
 ---
 

--- a/tests/testthat/_snaps/srr-ww_unsystematic_mse.md
+++ b/tests/testthat/_snaps/srr-ww_unsystematic_mse.md
@@ -70,26 +70,6 @@
       Caused by error in `yardstick_vec()`:
       ! `truth` must be numeric.
 
----
-
-    Code
-      ww_unsystematic_mse(list_df, x, y)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `estimate` must be numeric.
-
----
-
-    Code
-      ww_unsystematic_mse(list_df, y, x)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `truth` must be numeric.
-
 # srr: ww_unsystematic_mse removes NaN and NA when na_rm = TRUE
 
     Code

--- a/tests/testthat/_snaps/srr-ww_unsystematic_rmpd.md
+++ b/tests/testthat/_snaps/srr-ww_unsystematic_rmpd.md
@@ -70,26 +70,6 @@
       Caused by error in `yardstick_vec()`:
       ! `truth` must be numeric.
 
----
-
-    Code
-      ww_unsystematic_rmpd(list_df, x, y)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `estimate` must be numeric.
-
----
-
-    Code
-      ww_unsystematic_rmpd(list_df, y, x)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `truth` must be numeric.
-
 # srr: ww_unsystematic_rmpd removes NaN and NA when na_rm = TRUE
 
     Code

--- a/tests/testthat/_snaps/srr-ww_unsystematic_rmpd.md
+++ b/tests/testthat/_snaps/srr-ww_unsystematic_rmpd.md
@@ -1,4 +1,4 @@
-# srr: expected failures for ww_unsystematic_rmpd
+# srr: ww_unsystematic_rmpd errors if truth and estimate are different lengths
 
     Code
       ww_unsystematic_rmpd_vec(1:5, 1:4)
@@ -14,7 +14,7 @@
       Error in `yardstick_vec()`:
       ! Length of `truth` (4) and `estimate` (5) must match.
 
----
+# srr: ww_unsystematic_rmpd errors if truth and estimate aren't numeric
 
     Code
       ww_unsystematic_rmpd(char_df, x, y)
@@ -50,7 +50,7 @@
       Error in `yardstick_vec()`:
       ! `estimate` must be numeric.
 
----
+# srr: ww_unsystematic_rmpd errors if truth and estimate are list columns
 
     Code
       ww_unsystematic_rmpd(list_df, x, y)
@@ -71,6 +71,26 @@
       ! `truth` must be numeric.
 
 ---
+
+    Code
+      ww_unsystematic_rmpd(list_df, x, y)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `estimate` must be numeric.
+
+---
+
+    Code
+      ww_unsystematic_rmpd(list_df, y, x)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `truth` must be numeric.
+
+# srr: ww_unsystematic_rmpd removes NaN and NA when na_rm = TRUE
 
     Code
       round(ww_unsystematic_rmpd(missing_df, x, y)$.estimate, 15)
@@ -98,7 +118,7 @@
     Output
       [1] 0
 
----
+# srr: ww_unsystematic_rmpd errors on zero-length data
 
     Code
       ww_unsystematic_rmpd_vec(numeric(), numeric())
@@ -126,7 +146,7 @@
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
 
----
+# srr: ww_unsystematic_rmpd errors on all-NA data
 
     Code
       ww_unsystematic_rmpd_vec(rep(NA_real_, 4), 4:1)
@@ -161,6 +181,23 @@
       i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
+
+---
+
+    Code
+      ww_unsystematic_rmpd_vec(1:4, 1:4)
+    Output
+      [1] 0
+
+# srr: ww_unsystematic_rmpd works with all identical data
+
+    Code
+      ww_unsystematic_rmpd(all_identical, x, y)
+    Output
+      # A tibble: 1 x 3
+        .metric           .estimator .estimate
+        <chr>             <chr>          <dbl>
+      1 unsystematic_rmpd standard           0
 
 ---
 

--- a/tests/testthat/_snaps/srr-ww_unsystematic_rmse.md
+++ b/tests/testthat/_snaps/srr-ww_unsystematic_rmse.md
@@ -70,26 +70,6 @@
       Caused by error in `yardstick_vec()`:
       ! `truth` must be numeric.
 
----
-
-    Code
-      ww_unsystematic_rmse(list_df, x, y)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `estimate` must be numeric.
-
----
-
-    Code
-      ww_unsystematic_rmse(list_df, y, x)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `truth` must be numeric.
-
 # srr: ww_unsystematic_rmse removes NaN and NA when na_rm = TRUE
 
     Code

--- a/tests/testthat/_snaps/srr-ww_unsystematic_rmse.md
+++ b/tests/testthat/_snaps/srr-ww_unsystematic_rmse.md
@@ -1,4 +1,4 @@
-# srr: expected failures for ww_unsystematic_rmse
+# srr: ww_unsystematic_rmse errors if truth and estimate are different lengths
 
     Code
       ww_unsystematic_rmse_vec(1:5, 1:4)
@@ -14,7 +14,7 @@
       Error in `yardstick_vec()`:
       ! Length of `truth` (4) and `estimate` (5) must match.
 
----
+# srr: ww_unsystematic_rmse errors if truth and estimate aren't numeric
 
     Code
       ww_unsystematic_rmse(char_df, x, y)
@@ -50,7 +50,7 @@
       Error in `yardstick_vec()`:
       ! `estimate` must be numeric.
 
----
+# srr: ww_unsystematic_rmse errors if truth and estimate are list columns
 
     Code
       ww_unsystematic_rmse(list_df, x, y)
@@ -71,6 +71,26 @@
       ! `truth` must be numeric.
 
 ---
+
+    Code
+      ww_unsystematic_rmse(list_df, x, y)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `estimate` must be numeric.
+
+---
+
+    Code
+      ww_unsystematic_rmse(list_df, y, x)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `truth` must be numeric.
+
+# srr: ww_unsystematic_rmse removes NaN and NA when na_rm = TRUE
 
     Code
       round(ww_unsystematic_rmse(missing_df, x, y)$.estimate, 15)
@@ -98,7 +118,7 @@
     Output
       [1] 0
 
----
+# srr: ww_unsystematic_rmse errors on zero-length data
 
     Code
       ww_unsystematic_rmse_vec(numeric(), numeric())
@@ -126,7 +146,7 @@
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
 
----
+# srr: ww_unsystematic_rmse errors on all-NA data
 
     Code
       ww_unsystematic_rmse_vec(rep(NA_real_, 4), 4:1)
@@ -161,6 +181,23 @@
       i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
+
+---
+
+    Code
+      ww_unsystematic_rmse_vec(1:4, 1:4)
+    Output
+      [1] 0
+
+# srr: ww_unsystematic_rmse works with all identical data
+
+    Code
+      ww_unsystematic_rmse(all_identical, x, y)
+    Output
+      # A tibble: 1 x 3
+        .metric           .estimator .estimate
+        <chr>             <chr>          <dbl>
+      1 unsystematic_rmse standard           0
 
 ---
 

--- a/tests/testthat/_snaps/srr-ww_willmott_d.md
+++ b/tests/testthat/_snaps/srr-ww_willmott_d.md
@@ -1,4 +1,4 @@
-# srr: expected failures for ww_willmott_d
+# srr: ww_willmott_d errors if truth and estimate are different lengths
 
     Code
       ww_willmott_d_vec(1:5, 1:4)
@@ -14,7 +14,7 @@
       Error in `yardstick_vec()`:
       ! Length of `truth` (4) and `estimate` (5) must match.
 
----
+# srr: ww_willmott_d errors if truth and estimate aren't numeric
 
     Code
       ww_willmott_d(char_df, x, y)
@@ -50,7 +50,7 @@
       Error in `yardstick_vec()`:
       ! `estimate` must be numeric.
 
----
+# srr: ww_willmott_d errors if truth and estimate are list columns
 
     Code
       ww_willmott_d(list_df, x, y)
@@ -71,6 +71,26 @@
       ! `truth` must be numeric.
 
 ---
+
+    Code
+      ww_willmott_d(list_df, x, y)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `estimate` must be numeric.
+
+---
+
+    Code
+      ww_willmott_d(list_df, y, x)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `truth` must be numeric.
+
+# srr: ww_willmott_d removes NaN and NA when na_rm = TRUE
 
     Code
       round(ww_willmott_d(missing_df, x, y)$.estimate, 15)
@@ -98,7 +118,7 @@
     Output
       [1] 1
 
----
+# srr: ww_willmott_d errors on zero-length data
 
     Code
       ww_willmott_d_vec(numeric(), numeric())
@@ -126,7 +146,7 @@
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
 
----
+# srr: ww_willmott_d errors on all-NA data
 
     Code
       ww_willmott_d_vec(rep(NA_real_, 4), 4:1)
@@ -161,6 +181,23 @@
       i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
+
+---
+
+    Code
+      ww_willmott_d_vec(1:4, 1:4)
+    Output
+      [1] 1
+
+# srr: ww_willmott_d works with all identical data
+
+    Code
+      ww_willmott_d(all_identical, x, y)
+    Output
+      # A tibble: 1 x 3
+        .metric    .estimator .estimate
+        <chr>      <chr>          <dbl>
+      1 willmott_d standard           1
 
 ---
 

--- a/tests/testthat/_snaps/srr-ww_willmott_d.md
+++ b/tests/testthat/_snaps/srr-ww_willmott_d.md
@@ -70,26 +70,6 @@
       Caused by error in `yardstick_vec()`:
       ! `truth` must be numeric.
 
----
-
-    Code
-      ww_willmott_d(list_df, x, y)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `estimate` must be numeric.
-
----
-
-    Code
-      ww_willmott_d(list_df, y, x)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `truth` must be numeric.
-
 # srr: ww_willmott_d removes NaN and NA when na_rm = TRUE
 
     Code

--- a/tests/testthat/_snaps/srr-ww_willmott_d1.md
+++ b/tests/testthat/_snaps/srr-ww_willmott_d1.md
@@ -1,4 +1,4 @@
-# srr: expected failures for ww_willmott_d1
+# srr: ww_willmott_d1 errors if truth and estimate are different lengths
 
     Code
       ww_willmott_d1_vec(1:5, 1:4)
@@ -14,7 +14,7 @@
       Error in `yardstick_vec()`:
       ! Length of `truth` (4) and `estimate` (5) must match.
 
----
+# srr: ww_willmott_d1 errors if truth and estimate aren't numeric
 
     Code
       ww_willmott_d1(char_df, x, y)
@@ -50,7 +50,7 @@
       Error in `yardstick_vec()`:
       ! `estimate` must be numeric.
 
----
+# srr: ww_willmott_d1 errors if truth and estimate are list columns
 
     Code
       ww_willmott_d1(list_df, x, y)
@@ -71,6 +71,26 @@
       ! `truth` must be numeric.
 
 ---
+
+    Code
+      ww_willmott_d1(list_df, x, y)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `estimate` must be numeric.
+
+---
+
+    Code
+      ww_willmott_d1(list_df, y, x)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `truth` must be numeric.
+
+# srr: ww_willmott_d1 removes NaN and NA when na_rm = TRUE
 
     Code
       round(ww_willmott_d1(missing_df, x, y)$.estimate, 15)
@@ -98,7 +118,7 @@
     Output
       [1] 1
 
----
+# srr: ww_willmott_d1 errors on zero-length data
 
     Code
       ww_willmott_d1_vec(numeric(), numeric())
@@ -126,7 +146,7 @@
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
 
----
+# srr: ww_willmott_d1 errors on all-NA data
 
     Code
       ww_willmott_d1_vec(rep(NA_real_, 4), 4:1)
@@ -161,6 +181,23 @@
       i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
+
+---
+
+    Code
+      ww_willmott_d1_vec(1:4, 1:4)
+    Output
+      [1] 1
+
+# srr: ww_willmott_d1 works with all identical data
+
+    Code
+      ww_willmott_d1(all_identical, x, y)
+    Output
+      # A tibble: 1 x 3
+        .metric     .estimator .estimate
+        <chr>       <chr>          <dbl>
+      1 willmott_d1 standard           1
 
 ---
 

--- a/tests/testthat/_snaps/srr-ww_willmott_d1.md
+++ b/tests/testthat/_snaps/srr-ww_willmott_d1.md
@@ -70,26 +70,6 @@
       Caused by error in `yardstick_vec()`:
       ! `truth` must be numeric.
 
----
-
-    Code
-      ww_willmott_d1(list_df, x, y)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `estimate` must be numeric.
-
----
-
-    Code
-      ww_willmott_d1(list_df, y, x)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `truth` must be numeric.
-
 # srr: ww_willmott_d1 removes NaN and NA when na_rm = TRUE
 
     Code

--- a/tests/testthat/_snaps/srr-ww_willmott_dr.md
+++ b/tests/testthat/_snaps/srr-ww_willmott_dr.md
@@ -70,26 +70,6 @@
       Caused by error in `yardstick_vec()`:
       ! `truth` must be numeric.
 
----
-
-    Code
-      ww_willmott_dr(list_df, x, y)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `estimate` must be numeric.
-
----
-
-    Code
-      ww_willmott_dr(list_df, y, x)
-    Condition
-      Error in `dplyr::reframe()`:
-      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
-      Caused by error in `yardstick_vec()`:
-      ! `truth` must be numeric.
-
 # srr: ww_willmott_dr removes NaN and NA when na_rm = TRUE
 
     Code

--- a/tests/testthat/_snaps/srr-ww_willmott_dr.md
+++ b/tests/testthat/_snaps/srr-ww_willmott_dr.md
@@ -1,4 +1,4 @@
-# srr: expected failures for ww_willmott_dr
+# srr: ww_willmott_dr errors if truth and estimate are different lengths
 
     Code
       ww_willmott_dr_vec(1:5, 1:4)
@@ -14,7 +14,7 @@
       Error in `yardstick_vec()`:
       ! Length of `truth` (4) and `estimate` (5) must match.
 
----
+# srr: ww_willmott_dr errors if truth and estimate aren't numeric
 
     Code
       ww_willmott_dr(char_df, x, y)
@@ -50,7 +50,7 @@
       Error in `yardstick_vec()`:
       ! `estimate` must be numeric.
 
----
+# srr: ww_willmott_dr errors if truth and estimate are list columns
 
     Code
       ww_willmott_dr(list_df, x, y)
@@ -71,6 +71,26 @@
       ! `truth` must be numeric.
 
 ---
+
+    Code
+      ww_willmott_dr(list_df, x, y)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["x"]], estimate = .data[["y"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `estimate` must be numeric.
+
+---
+
+    Code
+      ww_willmott_dr(list_df, y, x)
+    Condition
+      Error in `dplyr::reframe()`:
+      i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
+      Caused by error in `yardstick_vec()`:
+      ! `truth` must be numeric.
+
+# srr: ww_willmott_dr removes NaN and NA when na_rm = TRUE
 
     Code
       round(ww_willmott_dr(missing_df, x, y)$.estimate, 15)
@@ -98,7 +118,7 @@
     Output
       [1] 1
 
----
+# srr: ww_willmott_dr errors on zero-length data
 
     Code
       ww_willmott_dr_vec(numeric(), numeric())
@@ -126,7 +146,7 @@
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
 
----
+# srr: ww_willmott_dr errors on all-NA data
 
     Code
       ww_willmott_dr_vec(rep(NA_real_, 4), 4:1)
@@ -161,6 +181,23 @@
       i In argument: `.estimate = fn(truth = .data[["y"]], estimate = .data[["x"]], na_rm = .env[["na_rm"]])`.
       Caused by error in `yardstick_vec()`:
       ! 0 non-missing values were passed to `truth`.
+
+---
+
+    Code
+      ww_willmott_dr_vec(1:4, 1:4)
+    Output
+      [1] 1
+
+# srr: ww_willmott_dr works with all identical data
+
+    Code
+      ww_willmott_dr(all_identical, x, y)
+    Output
+      # A tibble: 1 x 3
+        .metric     .estimator .estimate
+        <chr>       <chr>          <dbl>
+      1 willmott_dr standard           1
 
 ---
 

--- a/tests/testthat/test-srr-ww_agreement_coefficient.R
+++ b/tests/testthat/test-srr-ww_agreement_coefficient.R
@@ -1,187 +1,183 @@
 # This file was generated, do not edit by hand
 # Please edit inst/srr_template_nonspatial_yardstick.R instead
 
-test_that("srr: expected failures for ww_agreement_coefficient", {
+test_that("srr: ww_agreement_coefficient errors if truth and estimate are different lengths", {
   # Note that this test isn't applicable to data-frame input, which enforces
   # constant column lengths
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_agreement_coefficient_vec(1:5, 1:4),
     error = TRUE
   )
-
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_agreement_coefficient_vec(1:4, 1:5),
     error = TRUE
   )
+})
 
+test_that("srr: ww_agreement_coefficient errors if truth and estimate aren't numeric", {
   char_df <- tibble::tibble(x = 1:5, y = letters[1:5])
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_agreement_coefficient(char_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_agreement_coefficient(char_df, y, x),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_agreement_coefficient_vec(as.character(1:5), 1:4),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_agreement_coefficient_vec(1:5, as.character(1:4)),
     error = TRUE
   )
+})
 
+test_that("srr: ww_agreement_coefficient errors if truth and estimate are list columns", {
   list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_agreement_coefficient(list_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_agreement_coefficient(list_df, y, x),
     error = TRUE
   )
+})
 
-  #' @srrstats {G2.13} Missing data is properly handled
-  #' @srrstats {G2.15} Missingness is checked
-  #' @srrstats {G2.14} Users can specify behavior with NA results
-  #' @srrstats {G2.16} NaN is properly handled
+test_that("srr: ww_agreement_coefficient errors if truth and estimate are list columns", {
+  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
+  expect_snapshot(
+    ww_agreement_coefficient(list_df, x, y),
+    error = TRUE
+  )
+
+  expect_snapshot(
+    ww_agreement_coefficient(list_df, y, x),
+    error = TRUE
+  )
+})
+
+test_that("srr: ww_agreement_coefficient removes NaN and NA when na_rm = TRUE", {
+
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
-  #' Users can remove NA:
+
   expect_snapshot(
     round(ww_agreement_coefficient(missing_df, x, y)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_agreement_coefficient(missing_df, y, x)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_agreement_coefficient_vec(missing_df$y, missing_df$x), 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_agreement_coefficient_vec(missing_df$x, missing_df$y), 15),
   )
+})
 
-  #' @srrstats {G2.14b} Users can ignore NA:
+test_that("srr: ww_agreement_coefficient returns NA when na_rm = FALSE and NA is present", {
+
+  missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
+
   expect_identical(
     ww_agreement_coefficient(missing_df, y, x, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_agreement_coefficient(missing_df, x, y, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_agreement_coefficient_vec(missing_df$y, missing_df$x, na_rm = FALSE),
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_agreement_coefficient_vec(missing_df$x, missing_df$y, na_rm = FALSE),
     NA_real_
   )
 
-  # Edge condition tests: Zero-length data:
+})
+
+test_that("srr: ww_agreement_coefficient errors on zero-length data", {
+
   expect_snapshot(
     ww_agreement_coefficient_vec(numeric(), numeric()),
     error = TRUE
   )
 
   empty_df <- tibble::tibble(x = numeric(), y = numeric())
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_agreement_coefficient(empty_df, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_agreement_coefficient(empty_df, y, x),
     error = TRUE
   )
+})
 
-  # Edge condition tests: All-NA:
+test_that("srr: ww_agreement_coefficient errors on all-NA data", {
+
   expect_snapshot(
     ww_agreement_coefficient_vec(rep(NA_real_, 4), 4:1),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_agreement_coefficient_vec(1:4, rep(NA_real_, 4)),
     error = TRUE
   )
 
   all_na <- tibble::tibble(x = rep(NA_real_, 4), y = 1:4)
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_agreement_coefficient(all_na, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_agreement_coefficient(all_na, y, x),
     error = TRUE
   )
 
-  # Edge condition tests: All-identical:
+  expect_snapshot(
+    ww_agreement_coefficient_vec(1:4, 1:4)
+  )
+
+})
+
+
+test_that("srr: ww_agreement_coefficient works with all identical data", {
+
+  all_identical <- tibble::tibble(x = 1:4, y = 1:4)
+  expect_snapshot(
+    ww_agreement_coefficient(all_identical, x, y)
+  )
+
   expect_snapshot(
     ww_agreement_coefficient_vec(1:4, 1:4)
   )
 
   all_identical <- tibble::tibble(x = 1:4, y = 1:4)
-  # Edge condition tests: All-identical:
   expect_snapshot(
     ww_agreement_coefficient(all_identical, x, y)
   )
+
 })
 
-test_that("other generic srr standards", {
+test_that("srr: ww_agreement_coefficient results don't change with trivial noise", {
   skip_if_not_installed("withr")
   x <- c(6, 8, 9, 10, 11, 14)
   y <- c(2, 3, 5, 5, 6, 8)
@@ -189,31 +185,34 @@ test_that("other generic srr standards", {
   noised_x <- x + rnorm(x, .Machine$double.eps, .Machine$double.eps)
   noised_df <- tibble::tibble(x = noised_x, y = y)
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_agreement_coefficient(noised_df, x, y),
     ww_agreement_coefficient(df, x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_agreement_coefficient(noised_df, y, x),
     ww_agreement_coefficient(df, y, x)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_agreement_coefficient_vec(noised_x, y),
     ww_agreement_coefficient_vec(x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_agreement_coefficient_vec(y, noised_x),
     ww_agreement_coefficient_vec(y, x)
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
+})
+
+test_that("srr: ww_agreement_coefficient results don't change with different seeds", {
+  skip_if_not_installed("withr")
+  x <- c(6, 8, 9, 10, 11, 14)
+  y <- c(2, 3, 5, 5, 6, 8)
+  df <- tibble::tibble(x = x, y = y)
+
   expect_equal(
     withr::with_seed(
       123,
@@ -225,7 +224,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -237,7 +235,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -249,7 +246,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -260,4 +256,5 @@ test_that("other generic srr standards", {
       ww_agreement_coefficient_vec(y, x)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_agreement_coefficient.R
+++ b/tests/testthat/test-srr-ww_agreement_coefficient.R
@@ -50,19 +50,6 @@ test_that("srr: ww_agreement_coefficient errors if truth and estimate are list c
   )
 })
 
-test_that("srr: ww_agreement_coefficient errors if truth and estimate are list columns", {
-  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  expect_snapshot(
-    ww_agreement_coefficient(list_df, x, y),
-    error = TRUE
-  )
-
-  expect_snapshot(
-    ww_agreement_coefficient(list_df, y, x),
-    error = TRUE
-  )
-})
-
 test_that("srr: ww_agreement_coefficient removes NaN and NA when na_rm = TRUE", {
 
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))

--- a/tests/testthat/test-srr-ww_global_geary_c.R
+++ b/tests/testthat/test-srr-ww_global_geary_c.R
@@ -186,6 +186,7 @@ test_that("srr: expected failures for ww_global_geary_c", {
   expect_snapshot(
     ww_global_geary_c(worldclim_simulation, response, response)
   )
+
 })
 
 test_that("other generic srr standards", {
@@ -456,4 +457,5 @@ test_that("other generic srr standards", {
       ww_global_geary_c_vec(worldclim_loaded$bio13, worldclim_loaded$bio19, other_weights)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_global_geary_pvalue.R
+++ b/tests/testthat/test-srr-ww_global_geary_pvalue.R
@@ -186,6 +186,7 @@ test_that("srr: expected failures for ww_global_geary_pvalue", {
   expect_snapshot(
     ww_global_geary_pvalue(worldclim_simulation, response, response)
   )
+
 })
 
 test_that("other generic srr standards", {
@@ -456,4 +457,5 @@ test_that("other generic srr standards", {
       ww_global_geary_pvalue_vec(worldclim_loaded$bio13, worldclim_loaded$bio19, other_weights)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_global_moran_i.R
+++ b/tests/testthat/test-srr-ww_global_moran_i.R
@@ -186,6 +186,7 @@ test_that("srr: expected failures for ww_global_moran_i", {
   expect_snapshot(
     ww_global_moran_i(worldclim_simulation, response, response)
   )
+
 })
 
 test_that("other generic srr standards", {
@@ -456,4 +457,5 @@ test_that("other generic srr standards", {
       ww_global_moran_i_vec(worldclim_loaded$bio13, worldclim_loaded$bio19, other_weights)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_global_moran_pvalue.R
+++ b/tests/testthat/test-srr-ww_global_moran_pvalue.R
@@ -186,6 +186,7 @@ test_that("srr: expected failures for ww_global_moran_pvalue", {
   expect_snapshot(
     ww_global_moran_pvalue(worldclim_simulation, response, response)
   )
+
 })
 
 test_that("other generic srr standards", {
@@ -456,4 +457,5 @@ test_that("other generic srr standards", {
       ww_global_moran_pvalue_vec(worldclim_loaded$bio13, worldclim_loaded$bio19, other_weights)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_local_geary_c.R
+++ b/tests/testthat/test-srr-ww_local_geary_c.R
@@ -186,6 +186,7 @@ test_that("srr: expected failures for ww_local_geary_c", {
   expect_snapshot(
     ww_local_geary_c(worldclim_simulation, response, response)
   )
+
 })
 
 test_that("other generic srr standards", {
@@ -456,4 +457,5 @@ test_that("other generic srr standards", {
       ww_local_geary_c_vec(worldclim_loaded$bio13, worldclim_loaded$bio19, other_weights)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_local_geary_pvalue.R
+++ b/tests/testthat/test-srr-ww_local_geary_pvalue.R
@@ -186,6 +186,7 @@ test_that("srr: expected failures for ww_local_geary_pvalue", {
   expect_snapshot(
     ww_local_geary_pvalue(worldclim_simulation, response, response)
   )
+
 })
 
 test_that("other generic srr standards", {
@@ -281,8 +282,7 @@ test_that("other generic srr standards", {
     withr::with_seed(
       1107,
       ww_local_geary_pvalue(worldclim_predicted, predicted, response, nsim = 10000)
-    ),
-    tolerance = 0.1
+    ), tolerance = 0.1
   )
 
   #' @srrstats {G3.0} Testing with appropriate tolerances.
@@ -297,8 +297,7 @@ test_that("other generic srr standards", {
     withr::with_seed(
       1107,
       ww_local_geary_pvalue(worldclim_predicted, response, predicted, nsim = 10000)
-    ),
-    tolerance = 0.1
+    ), tolerance = 0.1
   )
 
   #' @srrstats {G3.0} Testing with appropriate tolerances.
@@ -313,8 +312,7 @@ test_that("other generic srr standards", {
     withr::with_seed(
       1107,
       ww_local_geary_pvalue_vec(worldclim_predicted$response, worldclim_predicted$predicted, worldclim_weights, nsim = 10000)
-    ),
-    tolerance = 0.1
+    ), tolerance = 0.1
   )
 
   #' @srrstats {G3.0} Testing with appropriate tolerances.
@@ -329,8 +327,7 @@ test_that("other generic srr standards", {
     withr::with_seed(
       1107,
       ww_local_geary_pvalue_vec(worldclim_predicted$predicted, worldclim_predicted$response, worldclim_weights, nsim = 10000)
-    ),
-    tolerance = 0.1
+    ), tolerance = 0.1
   )
 
   guerry_modeled <- guerry
@@ -348,8 +345,7 @@ test_that("other generic srr standards", {
   #' @srrstats {SP6.2} Testing with ~global data
   expect_equal(
     ww_local_geary_pvalue(guerry_modeled, predictions, Crm_prs, nsim = 10000)$.estimate,
-    ww_local_geary_pvalue(guerry_modeled_geo, predictions, Crm_prs, nsim = 10000)$.estimate,
-    tolerance = 0.1
+    ww_local_geary_pvalue(guerry_modeled_geo, predictions, Crm_prs, nsim = 10000)$.estimate, tolerance = 0.1
   )
 
   #' @srrstats {G3.0} Testing with appropriate tolerances.
@@ -358,8 +354,7 @@ test_that("other generic srr standards", {
   #' @srrstats {SP6.2} Testing with ~global data
   expect_equal(
     ww_local_geary_pvalue(guerry_modeled, Crm_prs, predictions, nsim = 10000)$.estimate,
-    ww_local_geary_pvalue(guerry_modeled_geo, Crm_prs, predictions, nsim = 10000)$.estimate,
-    tolerance = 0.1
+    ww_local_geary_pvalue(guerry_modeled_geo, Crm_prs, predictions, nsim = 10000)$.estimate, tolerance = 0.1
   )
 
   #' @srrstats {G3.0} Testing with appropriate tolerances.
@@ -368,8 +363,7 @@ test_that("other generic srr standards", {
   #' @srrstats {SP6.2} Testing with ~global data
   expect_equal(
     ww_local_geary_pvalue_vec(guerry_modeled$Crm_prs, guerry_modeled$predictions, guerry_weights, nsim = 10000),
-    ww_local_geary_pvalue_vec(guerry_modeled_geo$Crm_prs, guerry_modeled_geo$predictions, guerry_weights_geo, nsim = 10000),
-    tolerance = 0.1
+    ww_local_geary_pvalue_vec(guerry_modeled_geo$Crm_prs, guerry_modeled_geo$predictions, guerry_weights_geo, nsim = 10000), tolerance = 0.1
   )
 
   #' @srrstats {G3.0} Testing with appropriate tolerances.
@@ -378,8 +372,7 @@ test_that("other generic srr standards", {
   #' @srrstats {SP6.2} Testing with ~global data
   expect_equal(
     ww_local_geary_pvalue_vec(guerry_modeled$predictions, guerry_modeled$Crm_prs, guerry_weights, nsim = 10000),
-    ww_local_geary_pvalue_vec(guerry_modeled_geo$predictions, guerry_modeled_geo$Crm_prs, guerry_weights_geo, nsim = 10000),
-    tolerance = 0.1
+    ww_local_geary_pvalue_vec(guerry_modeled_geo$predictions, guerry_modeled_geo$Crm_prs, guerry_weights_geo, nsim = 10000), tolerance = 0.1
   )
 
   #' @srrstats {SP2.3} Testing with loaded sf objects:
@@ -464,4 +457,5 @@ test_that("other generic srr standards", {
       ww_local_geary_pvalue_vec(worldclim_loaded$bio13, worldclim_loaded$bio19, other_weights)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_local_getis_ord_g.R
+++ b/tests/testthat/test-srr-ww_local_getis_ord_g.R
@@ -186,6 +186,7 @@ test_that("srr: expected failures for ww_local_getis_ord_g", {
   expect_snapshot(
     ww_local_getis_ord_g(worldclim_simulation, response, response)
   )
+
 })
 
 test_that("other generic srr standards", {
@@ -456,4 +457,5 @@ test_that("other generic srr standards", {
       ww_local_getis_ord_g_vec(worldclim_loaded$bio13, worldclim_loaded$bio19, other_weights)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_local_getis_ord_g_pvalue.R
+++ b/tests/testthat/test-srr-ww_local_getis_ord_g_pvalue.R
@@ -186,6 +186,7 @@ test_that("srr: expected failures for ww_local_getis_ord_g_pvalue", {
   expect_snapshot(
     ww_local_getis_ord_g_pvalue(worldclim_simulation, response, response)
   )
+
 })
 
 test_that("other generic srr standards", {
@@ -281,8 +282,7 @@ test_that("other generic srr standards", {
     withr::with_seed(
       1107,
       ww_local_getis_ord_g_pvalue(worldclim_predicted, predicted, response, nsim = 10000)
-    ),
-    tolerance = 0.03
+    ), tolerance = 0.03
   )
 
   #' @srrstats {G3.0} Testing with appropriate tolerances.
@@ -297,8 +297,7 @@ test_that("other generic srr standards", {
     withr::with_seed(
       1107,
       ww_local_getis_ord_g_pvalue(worldclim_predicted, response, predicted, nsim = 10000)
-    ),
-    tolerance = 0.03
+    ), tolerance = 0.03
   )
 
   #' @srrstats {G3.0} Testing with appropriate tolerances.
@@ -313,8 +312,7 @@ test_that("other generic srr standards", {
     withr::with_seed(
       1107,
       ww_local_getis_ord_g_pvalue_vec(worldclim_predicted$response, worldclim_predicted$predicted, worldclim_weights, nsim = 10000)
-    ),
-    tolerance = 0.03
+    ), tolerance = 0.03
   )
 
   #' @srrstats {G3.0} Testing with appropriate tolerances.
@@ -329,8 +327,7 @@ test_that("other generic srr standards", {
     withr::with_seed(
       1107,
       ww_local_getis_ord_g_pvalue_vec(worldclim_predicted$predicted, worldclim_predicted$response, worldclim_weights, nsim = 10000)
-    ),
-    tolerance = 0.03
+    ), tolerance = 0.03
   )
 
   guerry_modeled <- guerry
@@ -348,8 +345,7 @@ test_that("other generic srr standards", {
   #' @srrstats {SP6.2} Testing with ~global data
   expect_equal(
     ww_local_getis_ord_g_pvalue(guerry_modeled, predictions, Crm_prs, nsim = 10000)$.estimate,
-    ww_local_getis_ord_g_pvalue(guerry_modeled_geo, predictions, Crm_prs, nsim = 10000)$.estimate,
-    tolerance = 0.03
+    ww_local_getis_ord_g_pvalue(guerry_modeled_geo, predictions, Crm_prs, nsim = 10000)$.estimate, tolerance = 0.03
   )
 
   #' @srrstats {G3.0} Testing with appropriate tolerances.
@@ -358,8 +354,7 @@ test_that("other generic srr standards", {
   #' @srrstats {SP6.2} Testing with ~global data
   expect_equal(
     ww_local_getis_ord_g_pvalue(guerry_modeled, Crm_prs, predictions, nsim = 10000)$.estimate,
-    ww_local_getis_ord_g_pvalue(guerry_modeled_geo, Crm_prs, predictions, nsim = 10000)$.estimate,
-    tolerance = 0.03
+    ww_local_getis_ord_g_pvalue(guerry_modeled_geo, Crm_prs, predictions, nsim = 10000)$.estimate, tolerance = 0.03
   )
 
   #' @srrstats {G3.0} Testing with appropriate tolerances.
@@ -368,8 +363,7 @@ test_that("other generic srr standards", {
   #' @srrstats {SP6.2} Testing with ~global data
   expect_equal(
     ww_local_getis_ord_g_pvalue_vec(guerry_modeled$Crm_prs, guerry_modeled$predictions, guerry_weights, nsim = 10000),
-    ww_local_getis_ord_g_pvalue_vec(guerry_modeled_geo$Crm_prs, guerry_modeled_geo$predictions, guerry_weights_geo, nsim = 10000),
-    tolerance = 0.03
+    ww_local_getis_ord_g_pvalue_vec(guerry_modeled_geo$Crm_prs, guerry_modeled_geo$predictions, guerry_weights_geo, nsim = 10000), tolerance = 0.03
   )
 
   #' @srrstats {G3.0} Testing with appropriate tolerances.
@@ -378,8 +372,7 @@ test_that("other generic srr standards", {
   #' @srrstats {SP6.2} Testing with ~global data
   expect_equal(
     ww_local_getis_ord_g_pvalue_vec(guerry_modeled$predictions, guerry_modeled$Crm_prs, guerry_weights, nsim = 10000),
-    ww_local_getis_ord_g_pvalue_vec(guerry_modeled_geo$predictions, guerry_modeled_geo$Crm_prs, guerry_weights_geo, nsim = 10000),
-    tolerance = 0.03
+    ww_local_getis_ord_g_pvalue_vec(guerry_modeled_geo$predictions, guerry_modeled_geo$Crm_prs, guerry_weights_geo, nsim = 10000), tolerance = 0.03
   )
 
   #' @srrstats {SP2.3} Testing with loaded sf objects:
@@ -464,4 +457,5 @@ test_that("other generic srr standards", {
       ww_local_getis_ord_g_pvalue_vec(worldclim_loaded$bio13, worldclim_loaded$bio19, other_weights)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_local_moran_i.R
+++ b/tests/testthat/test-srr-ww_local_moran_i.R
@@ -186,6 +186,7 @@ test_that("srr: expected failures for ww_local_moran_i", {
   expect_snapshot(
     ww_local_moran_i(worldclim_simulation, response, response)
   )
+
 })
 
 test_that("other generic srr standards", {
@@ -456,4 +457,5 @@ test_that("other generic srr standards", {
       ww_local_moran_i_vec(worldclim_loaded$bio13, worldclim_loaded$bio19, other_weights)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_local_moran_pvalue.R
+++ b/tests/testthat/test-srr-ww_local_moran_pvalue.R
@@ -186,6 +186,7 @@ test_that("srr: expected failures for ww_local_moran_pvalue", {
   expect_snapshot(
     ww_local_moran_pvalue(worldclim_simulation, response, response)
   )
+
 })
 
 test_that("other generic srr standards", {
@@ -456,4 +457,5 @@ test_that("other generic srr standards", {
       ww_local_moran_pvalue_vec(worldclim_loaded$bio13, worldclim_loaded$bio19, other_weights)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_systematic_agreement_coefficient.R
+++ b/tests/testthat/test-srr-ww_systematic_agreement_coefficient.R
@@ -1,187 +1,183 @@
 # This file was generated, do not edit by hand
 # Please edit inst/srr_template_nonspatial_yardstick.R instead
 
-test_that("srr: expected failures for ww_systematic_agreement_coefficient", {
+test_that("srr: ww_systematic_agreement_coefficient errors if truth and estimate are different lengths", {
   # Note that this test isn't applicable to data-frame input, which enforces
   # constant column lengths
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_systematic_agreement_coefficient_vec(1:5, 1:4),
     error = TRUE
   )
-
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_systematic_agreement_coefficient_vec(1:4, 1:5),
     error = TRUE
   )
+})
 
+test_that("srr: ww_systematic_agreement_coefficient errors if truth and estimate aren't numeric", {
   char_df <- tibble::tibble(x = 1:5, y = letters[1:5])
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_systematic_agreement_coefficient(char_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_systematic_agreement_coefficient(char_df, y, x),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_systematic_agreement_coefficient_vec(as.character(1:5), 1:4),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_systematic_agreement_coefficient_vec(1:5, as.character(1:4)),
     error = TRUE
   )
+})
 
+test_that("srr: ww_systematic_agreement_coefficient errors if truth and estimate are list columns", {
   list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_systematic_agreement_coefficient(list_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_systematic_agreement_coefficient(list_df, y, x),
     error = TRUE
   )
+})
 
-  #' @srrstats {G2.13} Missing data is properly handled
-  #' @srrstats {G2.15} Missingness is checked
-  #' @srrstats {G2.14} Users can specify behavior with NA results
-  #' @srrstats {G2.16} NaN is properly handled
+test_that("srr: ww_systematic_agreement_coefficient errors if truth and estimate are list columns", {
+  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
+  expect_snapshot(
+    ww_systematic_agreement_coefficient(list_df, x, y),
+    error = TRUE
+  )
+
+  expect_snapshot(
+    ww_systematic_agreement_coefficient(list_df, y, x),
+    error = TRUE
+  )
+})
+
+test_that("srr: ww_systematic_agreement_coefficient removes NaN and NA when na_rm = TRUE", {
+
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
-  #' Users can remove NA:
+
   expect_snapshot(
     round(ww_systematic_agreement_coefficient(missing_df, x, y)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_systematic_agreement_coefficient(missing_df, y, x)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_systematic_agreement_coefficient_vec(missing_df$y, missing_df$x), 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_systematic_agreement_coefficient_vec(missing_df$x, missing_df$y), 15),
   )
+})
 
-  #' @srrstats {G2.14b} Users can ignore NA:
+test_that("srr: ww_systematic_agreement_coefficient returns NA when na_rm = FALSE and NA is present", {
+
+  missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
+
   expect_identical(
     ww_systematic_agreement_coefficient(missing_df, y, x, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_systematic_agreement_coefficient(missing_df, x, y, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_systematic_agreement_coefficient_vec(missing_df$y, missing_df$x, na_rm = FALSE),
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_systematic_agreement_coefficient_vec(missing_df$x, missing_df$y, na_rm = FALSE),
     NA_real_
   )
 
-  # Edge condition tests: Zero-length data:
+})
+
+test_that("srr: ww_systematic_agreement_coefficient errors on zero-length data", {
+
   expect_snapshot(
     ww_systematic_agreement_coefficient_vec(numeric(), numeric()),
     error = TRUE
   )
 
   empty_df <- tibble::tibble(x = numeric(), y = numeric())
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_systematic_agreement_coefficient(empty_df, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_systematic_agreement_coefficient(empty_df, y, x),
     error = TRUE
   )
+})
 
-  # Edge condition tests: All-NA:
+test_that("srr: ww_systematic_agreement_coefficient errors on all-NA data", {
+
   expect_snapshot(
     ww_systematic_agreement_coefficient_vec(rep(NA_real_, 4), 4:1),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_systematic_agreement_coefficient_vec(1:4, rep(NA_real_, 4)),
     error = TRUE
   )
 
   all_na <- tibble::tibble(x = rep(NA_real_, 4), y = 1:4)
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_systematic_agreement_coefficient(all_na, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_systematic_agreement_coefficient(all_na, y, x),
     error = TRUE
   )
 
-  # Edge condition tests: All-identical:
+  expect_snapshot(
+    ww_systematic_agreement_coefficient_vec(1:4, 1:4)
+  )
+
+})
+
+
+test_that("srr: ww_systematic_agreement_coefficient works with all identical data", {
+
+  all_identical <- tibble::tibble(x = 1:4, y = 1:4)
+  expect_snapshot(
+    ww_systematic_agreement_coefficient(all_identical, x, y)
+  )
+
   expect_snapshot(
     ww_systematic_agreement_coefficient_vec(1:4, 1:4)
   )
 
   all_identical <- tibble::tibble(x = 1:4, y = 1:4)
-  # Edge condition tests: All-identical:
   expect_snapshot(
     ww_systematic_agreement_coefficient(all_identical, x, y)
   )
+
 })
 
-test_that("other generic srr standards", {
+test_that("srr: ww_systematic_agreement_coefficient results don't change with trivial noise", {
   skip_if_not_installed("withr")
   x <- c(6, 8, 9, 10, 11, 14)
   y <- c(2, 3, 5, 5, 6, 8)
@@ -189,31 +185,34 @@ test_that("other generic srr standards", {
   noised_x <- x + rnorm(x, .Machine$double.eps, .Machine$double.eps)
   noised_df <- tibble::tibble(x = noised_x, y = y)
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_systematic_agreement_coefficient(noised_df, x, y),
     ww_systematic_agreement_coefficient(df, x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_systematic_agreement_coefficient(noised_df, y, x),
     ww_systematic_agreement_coefficient(df, y, x)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_systematic_agreement_coefficient_vec(noised_x, y),
     ww_systematic_agreement_coefficient_vec(x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_systematic_agreement_coefficient_vec(y, noised_x),
     ww_systematic_agreement_coefficient_vec(y, x)
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
+})
+
+test_that("srr: ww_systematic_agreement_coefficient results don't change with different seeds", {
+  skip_if_not_installed("withr")
+  x <- c(6, 8, 9, 10, 11, 14)
+  y <- c(2, 3, 5, 5, 6, 8)
+  df <- tibble::tibble(x = x, y = y)
+
   expect_equal(
     withr::with_seed(
       123,
@@ -225,7 +224,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -237,7 +235,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -249,7 +246,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -260,4 +256,5 @@ test_that("other generic srr standards", {
       ww_systematic_agreement_coefficient_vec(y, x)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_systematic_agreement_coefficient.R
+++ b/tests/testthat/test-srr-ww_systematic_agreement_coefficient.R
@@ -50,19 +50,6 @@ test_that("srr: ww_systematic_agreement_coefficient errors if truth and estimate
   )
 })
 
-test_that("srr: ww_systematic_agreement_coefficient errors if truth and estimate are list columns", {
-  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  expect_snapshot(
-    ww_systematic_agreement_coefficient(list_df, x, y),
-    error = TRUE
-  )
-
-  expect_snapshot(
-    ww_systematic_agreement_coefficient(list_df, y, x),
-    error = TRUE
-  )
-})
-
 test_that("srr: ww_systematic_agreement_coefficient removes NaN and NA when na_rm = TRUE", {
 
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))

--- a/tests/testthat/test-srr-ww_systematic_mpd.R
+++ b/tests/testthat/test-srr-ww_systematic_mpd.R
@@ -50,19 +50,6 @@ test_that("srr: ww_systematic_mpd errors if truth and estimate are list columns"
   )
 })
 
-test_that("srr: ww_systematic_mpd errors if truth and estimate are list columns", {
-  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  expect_snapshot(
-    ww_systematic_mpd(list_df, x, y),
-    error = TRUE
-  )
-
-  expect_snapshot(
-    ww_systematic_mpd(list_df, y, x),
-    error = TRUE
-  )
-})
-
 test_that("srr: ww_systematic_mpd removes NaN and NA when na_rm = TRUE", {
 
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))

--- a/tests/testthat/test-srr-ww_systematic_mpd.R
+++ b/tests/testthat/test-srr-ww_systematic_mpd.R
@@ -1,187 +1,183 @@
 # This file was generated, do not edit by hand
 # Please edit inst/srr_template_nonspatial_yardstick.R instead
 
-test_that("srr: expected failures for ww_systematic_mpd", {
+test_that("srr: ww_systematic_mpd errors if truth and estimate are different lengths", {
   # Note that this test isn't applicable to data-frame input, which enforces
   # constant column lengths
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_systematic_mpd_vec(1:5, 1:4),
     error = TRUE
   )
-
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_systematic_mpd_vec(1:4, 1:5),
     error = TRUE
   )
+})
 
+test_that("srr: ww_systematic_mpd errors if truth and estimate aren't numeric", {
   char_df <- tibble::tibble(x = 1:5, y = letters[1:5])
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_systematic_mpd(char_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_systematic_mpd(char_df, y, x),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_systematic_mpd_vec(as.character(1:5), 1:4),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_systematic_mpd_vec(1:5, as.character(1:4)),
     error = TRUE
   )
+})
 
+test_that("srr: ww_systematic_mpd errors if truth and estimate are list columns", {
   list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_systematic_mpd(list_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_systematic_mpd(list_df, y, x),
     error = TRUE
   )
+})
 
-  #' @srrstats {G2.13} Missing data is properly handled
-  #' @srrstats {G2.15} Missingness is checked
-  #' @srrstats {G2.14} Users can specify behavior with NA results
-  #' @srrstats {G2.16} NaN is properly handled
+test_that("srr: ww_systematic_mpd errors if truth and estimate are list columns", {
+  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
+  expect_snapshot(
+    ww_systematic_mpd(list_df, x, y),
+    error = TRUE
+  )
+
+  expect_snapshot(
+    ww_systematic_mpd(list_df, y, x),
+    error = TRUE
+  )
+})
+
+test_that("srr: ww_systematic_mpd removes NaN and NA when na_rm = TRUE", {
+
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
-  #' Users can remove NA:
+
   expect_snapshot(
     round(ww_systematic_mpd(missing_df, x, y)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_systematic_mpd(missing_df, y, x)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_systematic_mpd_vec(missing_df$y, missing_df$x), 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_systematic_mpd_vec(missing_df$x, missing_df$y), 15),
   )
+})
 
-  #' @srrstats {G2.14b} Users can ignore NA:
+test_that("srr: ww_systematic_mpd returns NA when na_rm = FALSE and NA is present", {
+
+  missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
+
   expect_identical(
     ww_systematic_mpd(missing_df, y, x, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_systematic_mpd(missing_df, x, y, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_systematic_mpd_vec(missing_df$y, missing_df$x, na_rm = FALSE),
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_systematic_mpd_vec(missing_df$x, missing_df$y, na_rm = FALSE),
     NA_real_
   )
 
-  # Edge condition tests: Zero-length data:
+})
+
+test_that("srr: ww_systematic_mpd errors on zero-length data", {
+
   expect_snapshot(
     ww_systematic_mpd_vec(numeric(), numeric()),
     error = TRUE
   )
 
   empty_df <- tibble::tibble(x = numeric(), y = numeric())
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_systematic_mpd(empty_df, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_systematic_mpd(empty_df, y, x),
     error = TRUE
   )
+})
 
-  # Edge condition tests: All-NA:
+test_that("srr: ww_systematic_mpd errors on all-NA data", {
+
   expect_snapshot(
     ww_systematic_mpd_vec(rep(NA_real_, 4), 4:1),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_systematic_mpd_vec(1:4, rep(NA_real_, 4)),
     error = TRUE
   )
 
   all_na <- tibble::tibble(x = rep(NA_real_, 4), y = 1:4)
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_systematic_mpd(all_na, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_systematic_mpd(all_na, y, x),
     error = TRUE
   )
 
-  # Edge condition tests: All-identical:
+  expect_snapshot(
+    ww_systematic_mpd_vec(1:4, 1:4)
+  )
+
+})
+
+
+test_that("srr: ww_systematic_mpd works with all identical data", {
+
+  all_identical <- tibble::tibble(x = 1:4, y = 1:4)
+  expect_snapshot(
+    ww_systematic_mpd(all_identical, x, y)
+  )
+
   expect_snapshot(
     ww_systematic_mpd_vec(1:4, 1:4)
   )
 
   all_identical <- tibble::tibble(x = 1:4, y = 1:4)
-  # Edge condition tests: All-identical:
   expect_snapshot(
     ww_systematic_mpd(all_identical, x, y)
   )
+
 })
 
-test_that("other generic srr standards", {
+test_that("srr: ww_systematic_mpd results don't change with trivial noise", {
   skip_if_not_installed("withr")
   x <- c(6, 8, 9, 10, 11, 14)
   y <- c(2, 3, 5, 5, 6, 8)
@@ -189,31 +185,34 @@ test_that("other generic srr standards", {
   noised_x <- x + rnorm(x, .Machine$double.eps, .Machine$double.eps)
   noised_df <- tibble::tibble(x = noised_x, y = y)
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_systematic_mpd(noised_df, x, y),
     ww_systematic_mpd(df, x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_systematic_mpd(noised_df, y, x),
     ww_systematic_mpd(df, y, x)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_systematic_mpd_vec(noised_x, y),
     ww_systematic_mpd_vec(x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_systematic_mpd_vec(y, noised_x),
     ww_systematic_mpd_vec(y, x)
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
+})
+
+test_that("srr: ww_systematic_mpd results don't change with different seeds", {
+  skip_if_not_installed("withr")
+  x <- c(6, 8, 9, 10, 11, 14)
+  y <- c(2, 3, 5, 5, 6, 8)
+  df <- tibble::tibble(x = x, y = y)
+
   expect_equal(
     withr::with_seed(
       123,
@@ -225,7 +224,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -237,7 +235,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -249,7 +246,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -260,4 +256,5 @@ test_that("other generic srr standards", {
       ww_systematic_mpd_vec(y, x)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_systematic_mse.R
+++ b/tests/testthat/test-srr-ww_systematic_mse.R
@@ -1,187 +1,183 @@
 # This file was generated, do not edit by hand
 # Please edit inst/srr_template_nonspatial_yardstick.R instead
 
-test_that("srr: expected failures for ww_systematic_mse", {
+test_that("srr: ww_systematic_mse errors if truth and estimate are different lengths", {
   # Note that this test isn't applicable to data-frame input, which enforces
   # constant column lengths
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_systematic_mse_vec(1:5, 1:4),
     error = TRUE
   )
-
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_systematic_mse_vec(1:4, 1:5),
     error = TRUE
   )
+})
 
+test_that("srr: ww_systematic_mse errors if truth and estimate aren't numeric", {
   char_df <- tibble::tibble(x = 1:5, y = letters[1:5])
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_systematic_mse(char_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_systematic_mse(char_df, y, x),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_systematic_mse_vec(as.character(1:5), 1:4),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_systematic_mse_vec(1:5, as.character(1:4)),
     error = TRUE
   )
+})
 
+test_that("srr: ww_systematic_mse errors if truth and estimate are list columns", {
   list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_systematic_mse(list_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_systematic_mse(list_df, y, x),
     error = TRUE
   )
+})
 
-  #' @srrstats {G2.13} Missing data is properly handled
-  #' @srrstats {G2.15} Missingness is checked
-  #' @srrstats {G2.14} Users can specify behavior with NA results
-  #' @srrstats {G2.16} NaN is properly handled
+test_that("srr: ww_systematic_mse errors if truth and estimate are list columns", {
+  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
+  expect_snapshot(
+    ww_systematic_mse(list_df, x, y),
+    error = TRUE
+  )
+
+  expect_snapshot(
+    ww_systematic_mse(list_df, y, x),
+    error = TRUE
+  )
+})
+
+test_that("srr: ww_systematic_mse removes NaN and NA when na_rm = TRUE", {
+
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
-  #' Users can remove NA:
+
   expect_snapshot(
     round(ww_systematic_mse(missing_df, x, y)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_systematic_mse(missing_df, y, x)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_systematic_mse_vec(missing_df$y, missing_df$x), 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_systematic_mse_vec(missing_df$x, missing_df$y), 15),
   )
+})
 
-  #' @srrstats {G2.14b} Users can ignore NA:
+test_that("srr: ww_systematic_mse returns NA when na_rm = FALSE and NA is present", {
+
+  missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
+
   expect_identical(
     ww_systematic_mse(missing_df, y, x, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_systematic_mse(missing_df, x, y, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_systematic_mse_vec(missing_df$y, missing_df$x, na_rm = FALSE),
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_systematic_mse_vec(missing_df$x, missing_df$y, na_rm = FALSE),
     NA_real_
   )
 
-  # Edge condition tests: Zero-length data:
+})
+
+test_that("srr: ww_systematic_mse errors on zero-length data", {
+
   expect_snapshot(
     ww_systematic_mse_vec(numeric(), numeric()),
     error = TRUE
   )
 
   empty_df <- tibble::tibble(x = numeric(), y = numeric())
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_systematic_mse(empty_df, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_systematic_mse(empty_df, y, x),
     error = TRUE
   )
+})
 
-  # Edge condition tests: All-NA:
+test_that("srr: ww_systematic_mse errors on all-NA data", {
+
   expect_snapshot(
     ww_systematic_mse_vec(rep(NA_real_, 4), 4:1),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_systematic_mse_vec(1:4, rep(NA_real_, 4)),
     error = TRUE
   )
 
   all_na <- tibble::tibble(x = rep(NA_real_, 4), y = 1:4)
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_systematic_mse(all_na, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_systematic_mse(all_na, y, x),
     error = TRUE
   )
 
-  # Edge condition tests: All-identical:
+  expect_snapshot(
+    ww_systematic_mse_vec(1:4, 1:4)
+  )
+
+})
+
+
+test_that("srr: ww_systematic_mse works with all identical data", {
+
+  all_identical <- tibble::tibble(x = 1:4, y = 1:4)
+  expect_snapshot(
+    ww_systematic_mse(all_identical, x, y)
+  )
+
   expect_snapshot(
     ww_systematic_mse_vec(1:4, 1:4)
   )
 
   all_identical <- tibble::tibble(x = 1:4, y = 1:4)
-  # Edge condition tests: All-identical:
   expect_snapshot(
     ww_systematic_mse(all_identical, x, y)
   )
+
 })
 
-test_that("other generic srr standards", {
+test_that("srr: ww_systematic_mse results don't change with trivial noise", {
   skip_if_not_installed("withr")
   x <- c(6, 8, 9, 10, 11, 14)
   y <- c(2, 3, 5, 5, 6, 8)
@@ -189,31 +185,34 @@ test_that("other generic srr standards", {
   noised_x <- x + rnorm(x, .Machine$double.eps, .Machine$double.eps)
   noised_df <- tibble::tibble(x = noised_x, y = y)
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_systematic_mse(noised_df, x, y),
     ww_systematic_mse(df, x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_systematic_mse(noised_df, y, x),
     ww_systematic_mse(df, y, x)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_systematic_mse_vec(noised_x, y),
     ww_systematic_mse_vec(x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_systematic_mse_vec(y, noised_x),
     ww_systematic_mse_vec(y, x)
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
+})
+
+test_that("srr: ww_systematic_mse results don't change with different seeds", {
+  skip_if_not_installed("withr")
+  x <- c(6, 8, 9, 10, 11, 14)
+  y <- c(2, 3, 5, 5, 6, 8)
+  df <- tibble::tibble(x = x, y = y)
+
   expect_equal(
     withr::with_seed(
       123,
@@ -225,7 +224,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -237,7 +235,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -249,7 +246,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -260,4 +256,5 @@ test_that("other generic srr standards", {
       ww_systematic_mse_vec(y, x)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_systematic_mse.R
+++ b/tests/testthat/test-srr-ww_systematic_mse.R
@@ -50,19 +50,6 @@ test_that("srr: ww_systematic_mse errors if truth and estimate are list columns"
   )
 })
 
-test_that("srr: ww_systematic_mse errors if truth and estimate are list columns", {
-  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  expect_snapshot(
-    ww_systematic_mse(list_df, x, y),
-    error = TRUE
-  )
-
-  expect_snapshot(
-    ww_systematic_mse(list_df, y, x),
-    error = TRUE
-  )
-})
-
 test_that("srr: ww_systematic_mse removes NaN and NA when na_rm = TRUE", {
 
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))

--- a/tests/testthat/test-srr-ww_systematic_rmpd.R
+++ b/tests/testthat/test-srr-ww_systematic_rmpd.R
@@ -50,19 +50,6 @@ test_that("srr: ww_systematic_rmpd errors if truth and estimate are list columns
   )
 })
 
-test_that("srr: ww_systematic_rmpd errors if truth and estimate are list columns", {
-  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  expect_snapshot(
-    ww_systematic_rmpd(list_df, x, y),
-    error = TRUE
-  )
-
-  expect_snapshot(
-    ww_systematic_rmpd(list_df, y, x),
-    error = TRUE
-  )
-})
-
 test_that("srr: ww_systematic_rmpd removes NaN and NA when na_rm = TRUE", {
 
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))

--- a/tests/testthat/test-srr-ww_systematic_rmpd.R
+++ b/tests/testthat/test-srr-ww_systematic_rmpd.R
@@ -1,187 +1,183 @@
 # This file was generated, do not edit by hand
 # Please edit inst/srr_template_nonspatial_yardstick.R instead
 
-test_that("srr: expected failures for ww_systematic_rmpd", {
+test_that("srr: ww_systematic_rmpd errors if truth and estimate are different lengths", {
   # Note that this test isn't applicable to data-frame input, which enforces
   # constant column lengths
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_systematic_rmpd_vec(1:5, 1:4),
     error = TRUE
   )
-
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_systematic_rmpd_vec(1:4, 1:5),
     error = TRUE
   )
+})
 
+test_that("srr: ww_systematic_rmpd errors if truth and estimate aren't numeric", {
   char_df <- tibble::tibble(x = 1:5, y = letters[1:5])
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_systematic_rmpd(char_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_systematic_rmpd(char_df, y, x),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_systematic_rmpd_vec(as.character(1:5), 1:4),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_systematic_rmpd_vec(1:5, as.character(1:4)),
     error = TRUE
   )
+})
 
+test_that("srr: ww_systematic_rmpd errors if truth and estimate are list columns", {
   list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_systematic_rmpd(list_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_systematic_rmpd(list_df, y, x),
     error = TRUE
   )
+})
 
-  #' @srrstats {G2.13} Missing data is properly handled
-  #' @srrstats {G2.15} Missingness is checked
-  #' @srrstats {G2.14} Users can specify behavior with NA results
-  #' @srrstats {G2.16} NaN is properly handled
+test_that("srr: ww_systematic_rmpd errors if truth and estimate are list columns", {
+  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
+  expect_snapshot(
+    ww_systematic_rmpd(list_df, x, y),
+    error = TRUE
+  )
+
+  expect_snapshot(
+    ww_systematic_rmpd(list_df, y, x),
+    error = TRUE
+  )
+})
+
+test_that("srr: ww_systematic_rmpd removes NaN and NA when na_rm = TRUE", {
+
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
-  #' Users can remove NA:
+
   expect_snapshot(
     round(ww_systematic_rmpd(missing_df, x, y)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_systematic_rmpd(missing_df, y, x)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_systematic_rmpd_vec(missing_df$y, missing_df$x), 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_systematic_rmpd_vec(missing_df$x, missing_df$y), 15),
   )
+})
 
-  #' @srrstats {G2.14b} Users can ignore NA:
+test_that("srr: ww_systematic_rmpd returns NA when na_rm = FALSE and NA is present", {
+
+  missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
+
   expect_identical(
     ww_systematic_rmpd(missing_df, y, x, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_systematic_rmpd(missing_df, x, y, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_systematic_rmpd_vec(missing_df$y, missing_df$x, na_rm = FALSE),
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_systematic_rmpd_vec(missing_df$x, missing_df$y, na_rm = FALSE),
     NA_real_
   )
 
-  # Edge condition tests: Zero-length data:
+})
+
+test_that("srr: ww_systematic_rmpd errors on zero-length data", {
+
   expect_snapshot(
     ww_systematic_rmpd_vec(numeric(), numeric()),
     error = TRUE
   )
 
   empty_df <- tibble::tibble(x = numeric(), y = numeric())
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_systematic_rmpd(empty_df, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_systematic_rmpd(empty_df, y, x),
     error = TRUE
   )
+})
 
-  # Edge condition tests: All-NA:
+test_that("srr: ww_systematic_rmpd errors on all-NA data", {
+
   expect_snapshot(
     ww_systematic_rmpd_vec(rep(NA_real_, 4), 4:1),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_systematic_rmpd_vec(1:4, rep(NA_real_, 4)),
     error = TRUE
   )
 
   all_na <- tibble::tibble(x = rep(NA_real_, 4), y = 1:4)
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_systematic_rmpd(all_na, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_systematic_rmpd(all_na, y, x),
     error = TRUE
   )
 
-  # Edge condition tests: All-identical:
+  expect_snapshot(
+    ww_systematic_rmpd_vec(1:4, 1:4)
+  )
+
+})
+
+
+test_that("srr: ww_systematic_rmpd works with all identical data", {
+
+  all_identical <- tibble::tibble(x = 1:4, y = 1:4)
+  expect_snapshot(
+    ww_systematic_rmpd(all_identical, x, y)
+  )
+
   expect_snapshot(
     ww_systematic_rmpd_vec(1:4, 1:4)
   )
 
   all_identical <- tibble::tibble(x = 1:4, y = 1:4)
-  # Edge condition tests: All-identical:
   expect_snapshot(
     ww_systematic_rmpd(all_identical, x, y)
   )
+
 })
 
-test_that("other generic srr standards", {
+test_that("srr: ww_systematic_rmpd results don't change with trivial noise", {
   skip_if_not_installed("withr")
   x <- c(6, 8, 9, 10, 11, 14)
   y <- c(2, 3, 5, 5, 6, 8)
@@ -189,31 +185,34 @@ test_that("other generic srr standards", {
   noised_x <- x + rnorm(x, .Machine$double.eps, .Machine$double.eps)
   noised_df <- tibble::tibble(x = noised_x, y = y)
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_systematic_rmpd(noised_df, x, y),
     ww_systematic_rmpd(df, x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_systematic_rmpd(noised_df, y, x),
     ww_systematic_rmpd(df, y, x)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_systematic_rmpd_vec(noised_x, y),
     ww_systematic_rmpd_vec(x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_systematic_rmpd_vec(y, noised_x),
     ww_systematic_rmpd_vec(y, x)
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
+})
+
+test_that("srr: ww_systematic_rmpd results don't change with different seeds", {
+  skip_if_not_installed("withr")
+  x <- c(6, 8, 9, 10, 11, 14)
+  y <- c(2, 3, 5, 5, 6, 8)
+  df <- tibble::tibble(x = x, y = y)
+
   expect_equal(
     withr::with_seed(
       123,
@@ -225,7 +224,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -237,7 +235,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -249,7 +246,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -260,4 +256,5 @@ test_that("other generic srr standards", {
       ww_systematic_rmpd_vec(y, x)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_systematic_rmse.R
+++ b/tests/testthat/test-srr-ww_systematic_rmse.R
@@ -50,19 +50,6 @@ test_that("srr: ww_systematic_rmse errors if truth and estimate are list columns
   )
 })
 
-test_that("srr: ww_systematic_rmse errors if truth and estimate are list columns", {
-  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  expect_snapshot(
-    ww_systematic_rmse(list_df, x, y),
-    error = TRUE
-  )
-
-  expect_snapshot(
-    ww_systematic_rmse(list_df, y, x),
-    error = TRUE
-  )
-})
-
 test_that("srr: ww_systematic_rmse removes NaN and NA when na_rm = TRUE", {
 
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))

--- a/tests/testthat/test-srr-ww_systematic_rmse.R
+++ b/tests/testthat/test-srr-ww_systematic_rmse.R
@@ -1,187 +1,183 @@
 # This file was generated, do not edit by hand
 # Please edit inst/srr_template_nonspatial_yardstick.R instead
 
-test_that("srr: expected failures for ww_systematic_rmse", {
+test_that("srr: ww_systematic_rmse errors if truth and estimate are different lengths", {
   # Note that this test isn't applicable to data-frame input, which enforces
   # constant column lengths
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_systematic_rmse_vec(1:5, 1:4),
     error = TRUE
   )
-
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_systematic_rmse_vec(1:4, 1:5),
     error = TRUE
   )
+})
 
+test_that("srr: ww_systematic_rmse errors if truth and estimate aren't numeric", {
   char_df <- tibble::tibble(x = 1:5, y = letters[1:5])
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_systematic_rmse(char_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_systematic_rmse(char_df, y, x),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_systematic_rmse_vec(as.character(1:5), 1:4),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_systematic_rmse_vec(1:5, as.character(1:4)),
     error = TRUE
   )
+})
 
+test_that("srr: ww_systematic_rmse errors if truth and estimate are list columns", {
   list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_systematic_rmse(list_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_systematic_rmse(list_df, y, x),
     error = TRUE
   )
+})
 
-  #' @srrstats {G2.13} Missing data is properly handled
-  #' @srrstats {G2.15} Missingness is checked
-  #' @srrstats {G2.14} Users can specify behavior with NA results
-  #' @srrstats {G2.16} NaN is properly handled
+test_that("srr: ww_systematic_rmse errors if truth and estimate are list columns", {
+  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
+  expect_snapshot(
+    ww_systematic_rmse(list_df, x, y),
+    error = TRUE
+  )
+
+  expect_snapshot(
+    ww_systematic_rmse(list_df, y, x),
+    error = TRUE
+  )
+})
+
+test_that("srr: ww_systematic_rmse removes NaN and NA when na_rm = TRUE", {
+
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
-  #' Users can remove NA:
+
   expect_snapshot(
     round(ww_systematic_rmse(missing_df, x, y)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_systematic_rmse(missing_df, y, x)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_systematic_rmse_vec(missing_df$y, missing_df$x), 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_systematic_rmse_vec(missing_df$x, missing_df$y), 15),
   )
+})
 
-  #' @srrstats {G2.14b} Users can ignore NA:
+test_that("srr: ww_systematic_rmse returns NA when na_rm = FALSE and NA is present", {
+
+  missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
+
   expect_identical(
     ww_systematic_rmse(missing_df, y, x, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_systematic_rmse(missing_df, x, y, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_systematic_rmse_vec(missing_df$y, missing_df$x, na_rm = FALSE),
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_systematic_rmse_vec(missing_df$x, missing_df$y, na_rm = FALSE),
     NA_real_
   )
 
-  # Edge condition tests: Zero-length data:
+})
+
+test_that("srr: ww_systematic_rmse errors on zero-length data", {
+
   expect_snapshot(
     ww_systematic_rmse_vec(numeric(), numeric()),
     error = TRUE
   )
 
   empty_df <- tibble::tibble(x = numeric(), y = numeric())
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_systematic_rmse(empty_df, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_systematic_rmse(empty_df, y, x),
     error = TRUE
   )
+})
 
-  # Edge condition tests: All-NA:
+test_that("srr: ww_systematic_rmse errors on all-NA data", {
+
   expect_snapshot(
     ww_systematic_rmse_vec(rep(NA_real_, 4), 4:1),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_systematic_rmse_vec(1:4, rep(NA_real_, 4)),
     error = TRUE
   )
 
   all_na <- tibble::tibble(x = rep(NA_real_, 4), y = 1:4)
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_systematic_rmse(all_na, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_systematic_rmse(all_na, y, x),
     error = TRUE
   )
 
-  # Edge condition tests: All-identical:
+  expect_snapshot(
+    ww_systematic_rmse_vec(1:4, 1:4)
+  )
+
+})
+
+
+test_that("srr: ww_systematic_rmse works with all identical data", {
+
+  all_identical <- tibble::tibble(x = 1:4, y = 1:4)
+  expect_snapshot(
+    ww_systematic_rmse(all_identical, x, y)
+  )
+
   expect_snapshot(
     ww_systematic_rmse_vec(1:4, 1:4)
   )
 
   all_identical <- tibble::tibble(x = 1:4, y = 1:4)
-  # Edge condition tests: All-identical:
   expect_snapshot(
     ww_systematic_rmse(all_identical, x, y)
   )
+
 })
 
-test_that("other generic srr standards", {
+test_that("srr: ww_systematic_rmse results don't change with trivial noise", {
   skip_if_not_installed("withr")
   x <- c(6, 8, 9, 10, 11, 14)
   y <- c(2, 3, 5, 5, 6, 8)
@@ -189,31 +185,34 @@ test_that("other generic srr standards", {
   noised_x <- x + rnorm(x, .Machine$double.eps, .Machine$double.eps)
   noised_df <- tibble::tibble(x = noised_x, y = y)
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_systematic_rmse(noised_df, x, y),
     ww_systematic_rmse(df, x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_systematic_rmse(noised_df, y, x),
     ww_systematic_rmse(df, y, x)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_systematic_rmse_vec(noised_x, y),
     ww_systematic_rmse_vec(x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_systematic_rmse_vec(y, noised_x),
     ww_systematic_rmse_vec(y, x)
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
+})
+
+test_that("srr: ww_systematic_rmse results don't change with different seeds", {
+  skip_if_not_installed("withr")
+  x <- c(6, 8, 9, 10, 11, 14)
+  y <- c(2, 3, 5, 5, 6, 8)
+  df <- tibble::tibble(x = x, y = y)
+
   expect_equal(
     withr::with_seed(
       123,
@@ -225,7 +224,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -237,7 +235,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -249,7 +246,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -260,4 +256,5 @@ test_that("other generic srr standards", {
       ww_systematic_rmse_vec(y, x)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_unsystematic_agreement_coefficient.R
+++ b/tests/testthat/test-srr-ww_unsystematic_agreement_coefficient.R
@@ -50,19 +50,6 @@ test_that("srr: ww_unsystematic_agreement_coefficient errors if truth and estima
   )
 })
 
-test_that("srr: ww_unsystematic_agreement_coefficient errors if truth and estimate are list columns", {
-  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  expect_snapshot(
-    ww_unsystematic_agreement_coefficient(list_df, x, y),
-    error = TRUE
-  )
-
-  expect_snapshot(
-    ww_unsystematic_agreement_coefficient(list_df, y, x),
-    error = TRUE
-  )
-})
-
 test_that("srr: ww_unsystematic_agreement_coefficient removes NaN and NA when na_rm = TRUE", {
 
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))

--- a/tests/testthat/test-srr-ww_unsystematic_agreement_coefficient.R
+++ b/tests/testthat/test-srr-ww_unsystematic_agreement_coefficient.R
@@ -1,187 +1,183 @@
 # This file was generated, do not edit by hand
 # Please edit inst/srr_template_nonspatial_yardstick.R instead
 
-test_that("srr: expected failures for ww_unsystematic_agreement_coefficient", {
+test_that("srr: ww_unsystematic_agreement_coefficient errors if truth and estimate are different lengths", {
   # Note that this test isn't applicable to data-frame input, which enforces
   # constant column lengths
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_unsystematic_agreement_coefficient_vec(1:5, 1:4),
     error = TRUE
   )
-
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_unsystematic_agreement_coefficient_vec(1:4, 1:5),
     error = TRUE
   )
+})
 
+test_that("srr: ww_unsystematic_agreement_coefficient errors if truth and estimate aren't numeric", {
   char_df <- tibble::tibble(x = 1:5, y = letters[1:5])
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_unsystematic_agreement_coefficient(char_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_unsystematic_agreement_coefficient(char_df, y, x),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_unsystematic_agreement_coefficient_vec(as.character(1:5), 1:4),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_unsystematic_agreement_coefficient_vec(1:5, as.character(1:4)),
     error = TRUE
   )
+})
 
+test_that("srr: ww_unsystematic_agreement_coefficient errors if truth and estimate are list columns", {
   list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_unsystematic_agreement_coefficient(list_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_unsystematic_agreement_coefficient(list_df, y, x),
     error = TRUE
   )
+})
 
-  #' @srrstats {G2.13} Missing data is properly handled
-  #' @srrstats {G2.15} Missingness is checked
-  #' @srrstats {G2.14} Users can specify behavior with NA results
-  #' @srrstats {G2.16} NaN is properly handled
+test_that("srr: ww_unsystematic_agreement_coefficient errors if truth and estimate are list columns", {
+  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
+  expect_snapshot(
+    ww_unsystematic_agreement_coefficient(list_df, x, y),
+    error = TRUE
+  )
+
+  expect_snapshot(
+    ww_unsystematic_agreement_coefficient(list_df, y, x),
+    error = TRUE
+  )
+})
+
+test_that("srr: ww_unsystematic_agreement_coefficient removes NaN and NA when na_rm = TRUE", {
+
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
-  #' Users can remove NA:
+
   expect_snapshot(
     round(ww_unsystematic_agreement_coefficient(missing_df, x, y)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_unsystematic_agreement_coefficient(missing_df, y, x)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_unsystematic_agreement_coefficient_vec(missing_df$y, missing_df$x), 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_unsystematic_agreement_coefficient_vec(missing_df$x, missing_df$y), 15),
   )
+})
 
-  #' @srrstats {G2.14b} Users can ignore NA:
+test_that("srr: ww_unsystematic_agreement_coefficient returns NA when na_rm = FALSE and NA is present", {
+
+  missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
+
   expect_identical(
     ww_unsystematic_agreement_coefficient(missing_df, y, x, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_unsystematic_agreement_coefficient(missing_df, x, y, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_unsystematic_agreement_coefficient_vec(missing_df$y, missing_df$x, na_rm = FALSE),
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_unsystematic_agreement_coefficient_vec(missing_df$x, missing_df$y, na_rm = FALSE),
     NA_real_
   )
 
-  # Edge condition tests: Zero-length data:
+})
+
+test_that("srr: ww_unsystematic_agreement_coefficient errors on zero-length data", {
+
   expect_snapshot(
     ww_unsystematic_agreement_coefficient_vec(numeric(), numeric()),
     error = TRUE
   )
 
   empty_df <- tibble::tibble(x = numeric(), y = numeric())
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_unsystematic_agreement_coefficient(empty_df, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_unsystematic_agreement_coefficient(empty_df, y, x),
     error = TRUE
   )
+})
 
-  # Edge condition tests: All-NA:
+test_that("srr: ww_unsystematic_agreement_coefficient errors on all-NA data", {
+
   expect_snapshot(
     ww_unsystematic_agreement_coefficient_vec(rep(NA_real_, 4), 4:1),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_unsystematic_agreement_coefficient_vec(1:4, rep(NA_real_, 4)),
     error = TRUE
   )
 
   all_na <- tibble::tibble(x = rep(NA_real_, 4), y = 1:4)
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_unsystematic_agreement_coefficient(all_na, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_unsystematic_agreement_coefficient(all_na, y, x),
     error = TRUE
   )
 
-  # Edge condition tests: All-identical:
+  expect_snapshot(
+    ww_unsystematic_agreement_coefficient_vec(1:4, 1:4)
+  )
+
+})
+
+
+test_that("srr: ww_unsystematic_agreement_coefficient works with all identical data", {
+
+  all_identical <- tibble::tibble(x = 1:4, y = 1:4)
+  expect_snapshot(
+    ww_unsystematic_agreement_coefficient(all_identical, x, y)
+  )
+
   expect_snapshot(
     ww_unsystematic_agreement_coefficient_vec(1:4, 1:4)
   )
 
   all_identical <- tibble::tibble(x = 1:4, y = 1:4)
-  # Edge condition tests: All-identical:
   expect_snapshot(
     ww_unsystematic_agreement_coefficient(all_identical, x, y)
   )
+
 })
 
-test_that("other generic srr standards", {
+test_that("srr: ww_unsystematic_agreement_coefficient results don't change with trivial noise", {
   skip_if_not_installed("withr")
   x <- c(6, 8, 9, 10, 11, 14)
   y <- c(2, 3, 5, 5, 6, 8)
@@ -189,31 +185,34 @@ test_that("other generic srr standards", {
   noised_x <- x + rnorm(x, .Machine$double.eps, .Machine$double.eps)
   noised_df <- tibble::tibble(x = noised_x, y = y)
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_unsystematic_agreement_coefficient(noised_df, x, y),
     ww_unsystematic_agreement_coefficient(df, x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_unsystematic_agreement_coefficient(noised_df, y, x),
     ww_unsystematic_agreement_coefficient(df, y, x)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_unsystematic_agreement_coefficient_vec(noised_x, y),
     ww_unsystematic_agreement_coefficient_vec(x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_unsystematic_agreement_coefficient_vec(y, noised_x),
     ww_unsystematic_agreement_coefficient_vec(y, x)
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
+})
+
+test_that("srr: ww_unsystematic_agreement_coefficient results don't change with different seeds", {
+  skip_if_not_installed("withr")
+  x <- c(6, 8, 9, 10, 11, 14)
+  y <- c(2, 3, 5, 5, 6, 8)
+  df <- tibble::tibble(x = x, y = y)
+
   expect_equal(
     withr::with_seed(
       123,
@@ -225,7 +224,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -237,7 +235,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -249,7 +246,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -260,4 +256,5 @@ test_that("other generic srr standards", {
       ww_unsystematic_agreement_coefficient_vec(y, x)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_unsystematic_mpd.R
+++ b/tests/testthat/test-srr-ww_unsystematic_mpd.R
@@ -1,187 +1,183 @@
 # This file was generated, do not edit by hand
 # Please edit inst/srr_template_nonspatial_yardstick.R instead
 
-test_that("srr: expected failures for ww_unsystematic_mpd", {
+test_that("srr: ww_unsystematic_mpd errors if truth and estimate are different lengths", {
   # Note that this test isn't applicable to data-frame input, which enforces
   # constant column lengths
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_unsystematic_mpd_vec(1:5, 1:4),
     error = TRUE
   )
-
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_unsystematic_mpd_vec(1:4, 1:5),
     error = TRUE
   )
+})
 
+test_that("srr: ww_unsystematic_mpd errors if truth and estimate aren't numeric", {
   char_df <- tibble::tibble(x = 1:5, y = letters[1:5])
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_unsystematic_mpd(char_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_unsystematic_mpd(char_df, y, x),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_unsystematic_mpd_vec(as.character(1:5), 1:4),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_unsystematic_mpd_vec(1:5, as.character(1:4)),
     error = TRUE
   )
+})
 
+test_that("srr: ww_unsystematic_mpd errors if truth and estimate are list columns", {
   list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_unsystematic_mpd(list_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_unsystematic_mpd(list_df, y, x),
     error = TRUE
   )
+})
 
-  #' @srrstats {G2.13} Missing data is properly handled
-  #' @srrstats {G2.15} Missingness is checked
-  #' @srrstats {G2.14} Users can specify behavior with NA results
-  #' @srrstats {G2.16} NaN is properly handled
+test_that("srr: ww_unsystematic_mpd errors if truth and estimate are list columns", {
+  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
+  expect_snapshot(
+    ww_unsystematic_mpd(list_df, x, y),
+    error = TRUE
+  )
+
+  expect_snapshot(
+    ww_unsystematic_mpd(list_df, y, x),
+    error = TRUE
+  )
+})
+
+test_that("srr: ww_unsystematic_mpd removes NaN and NA when na_rm = TRUE", {
+
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
-  #' Users can remove NA:
+
   expect_snapshot(
     round(ww_unsystematic_mpd(missing_df, x, y)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_unsystematic_mpd(missing_df, y, x)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_unsystematic_mpd_vec(missing_df$y, missing_df$x), 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_unsystematic_mpd_vec(missing_df$x, missing_df$y), 15),
   )
+})
 
-  #' @srrstats {G2.14b} Users can ignore NA:
+test_that("srr: ww_unsystematic_mpd returns NA when na_rm = FALSE and NA is present", {
+
+  missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
+
   expect_identical(
     ww_unsystematic_mpd(missing_df, y, x, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_unsystematic_mpd(missing_df, x, y, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_unsystematic_mpd_vec(missing_df$y, missing_df$x, na_rm = FALSE),
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_unsystematic_mpd_vec(missing_df$x, missing_df$y, na_rm = FALSE),
     NA_real_
   )
 
-  # Edge condition tests: Zero-length data:
+})
+
+test_that("srr: ww_unsystematic_mpd errors on zero-length data", {
+
   expect_snapshot(
     ww_unsystematic_mpd_vec(numeric(), numeric()),
     error = TRUE
   )
 
   empty_df <- tibble::tibble(x = numeric(), y = numeric())
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_unsystematic_mpd(empty_df, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_unsystematic_mpd(empty_df, y, x),
     error = TRUE
   )
+})
 
-  # Edge condition tests: All-NA:
+test_that("srr: ww_unsystematic_mpd errors on all-NA data", {
+
   expect_snapshot(
     ww_unsystematic_mpd_vec(rep(NA_real_, 4), 4:1),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_unsystematic_mpd_vec(1:4, rep(NA_real_, 4)),
     error = TRUE
   )
 
   all_na <- tibble::tibble(x = rep(NA_real_, 4), y = 1:4)
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_unsystematic_mpd(all_na, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_unsystematic_mpd(all_na, y, x),
     error = TRUE
   )
 
-  # Edge condition tests: All-identical:
+  expect_snapshot(
+    ww_unsystematic_mpd_vec(1:4, 1:4)
+  )
+
+})
+
+
+test_that("srr: ww_unsystematic_mpd works with all identical data", {
+
+  all_identical <- tibble::tibble(x = 1:4, y = 1:4)
+  expect_snapshot(
+    ww_unsystematic_mpd(all_identical, x, y)
+  )
+
   expect_snapshot(
     ww_unsystematic_mpd_vec(1:4, 1:4)
   )
 
   all_identical <- tibble::tibble(x = 1:4, y = 1:4)
-  # Edge condition tests: All-identical:
   expect_snapshot(
     ww_unsystematic_mpd(all_identical, x, y)
   )
+
 })
 
-test_that("other generic srr standards", {
+test_that("srr: ww_unsystematic_mpd results don't change with trivial noise", {
   skip_if_not_installed("withr")
   x <- c(6, 8, 9, 10, 11, 14)
   y <- c(2, 3, 5, 5, 6, 8)
@@ -189,31 +185,34 @@ test_that("other generic srr standards", {
   noised_x <- x + rnorm(x, .Machine$double.eps, .Machine$double.eps)
   noised_df <- tibble::tibble(x = noised_x, y = y)
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_unsystematic_mpd(noised_df, x, y),
     ww_unsystematic_mpd(df, x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_unsystematic_mpd(noised_df, y, x),
     ww_unsystematic_mpd(df, y, x)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_unsystematic_mpd_vec(noised_x, y),
     ww_unsystematic_mpd_vec(x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_unsystematic_mpd_vec(y, noised_x),
     ww_unsystematic_mpd_vec(y, x)
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
+})
+
+test_that("srr: ww_unsystematic_mpd results don't change with different seeds", {
+  skip_if_not_installed("withr")
+  x <- c(6, 8, 9, 10, 11, 14)
+  y <- c(2, 3, 5, 5, 6, 8)
+  df <- tibble::tibble(x = x, y = y)
+
   expect_equal(
     withr::with_seed(
       123,
@@ -225,7 +224,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -237,7 +235,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -249,7 +246,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -260,4 +256,5 @@ test_that("other generic srr standards", {
       ww_unsystematic_mpd_vec(y, x)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_unsystematic_mpd.R
+++ b/tests/testthat/test-srr-ww_unsystematic_mpd.R
@@ -50,19 +50,6 @@ test_that("srr: ww_unsystematic_mpd errors if truth and estimate are list column
   )
 })
 
-test_that("srr: ww_unsystematic_mpd errors if truth and estimate are list columns", {
-  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  expect_snapshot(
-    ww_unsystematic_mpd(list_df, x, y),
-    error = TRUE
-  )
-
-  expect_snapshot(
-    ww_unsystematic_mpd(list_df, y, x),
-    error = TRUE
-  )
-})
-
 test_that("srr: ww_unsystematic_mpd removes NaN and NA when na_rm = TRUE", {
 
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))

--- a/tests/testthat/test-srr-ww_unsystematic_mse.R
+++ b/tests/testthat/test-srr-ww_unsystematic_mse.R
@@ -1,187 +1,183 @@
 # This file was generated, do not edit by hand
 # Please edit inst/srr_template_nonspatial_yardstick.R instead
 
-test_that("srr: expected failures for ww_unsystematic_mse", {
+test_that("srr: ww_unsystematic_mse errors if truth and estimate are different lengths", {
   # Note that this test isn't applicable to data-frame input, which enforces
   # constant column lengths
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_unsystematic_mse_vec(1:5, 1:4),
     error = TRUE
   )
-
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_unsystematic_mse_vec(1:4, 1:5),
     error = TRUE
   )
+})
 
+test_that("srr: ww_unsystematic_mse errors if truth and estimate aren't numeric", {
   char_df <- tibble::tibble(x = 1:5, y = letters[1:5])
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_unsystematic_mse(char_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_unsystematic_mse(char_df, y, x),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_unsystematic_mse_vec(as.character(1:5), 1:4),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_unsystematic_mse_vec(1:5, as.character(1:4)),
     error = TRUE
   )
+})
 
+test_that("srr: ww_unsystematic_mse errors if truth and estimate are list columns", {
   list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_unsystematic_mse(list_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_unsystematic_mse(list_df, y, x),
     error = TRUE
   )
+})
 
-  #' @srrstats {G2.13} Missing data is properly handled
-  #' @srrstats {G2.15} Missingness is checked
-  #' @srrstats {G2.14} Users can specify behavior with NA results
-  #' @srrstats {G2.16} NaN is properly handled
+test_that("srr: ww_unsystematic_mse errors if truth and estimate are list columns", {
+  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
+  expect_snapshot(
+    ww_unsystematic_mse(list_df, x, y),
+    error = TRUE
+  )
+
+  expect_snapshot(
+    ww_unsystematic_mse(list_df, y, x),
+    error = TRUE
+  )
+})
+
+test_that("srr: ww_unsystematic_mse removes NaN and NA when na_rm = TRUE", {
+
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
-  #' Users can remove NA:
+
   expect_snapshot(
     round(ww_unsystematic_mse(missing_df, x, y)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_unsystematic_mse(missing_df, y, x)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_unsystematic_mse_vec(missing_df$y, missing_df$x), 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_unsystematic_mse_vec(missing_df$x, missing_df$y), 15),
   )
+})
 
-  #' @srrstats {G2.14b} Users can ignore NA:
+test_that("srr: ww_unsystematic_mse returns NA when na_rm = FALSE and NA is present", {
+
+  missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
+
   expect_identical(
     ww_unsystematic_mse(missing_df, y, x, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_unsystematic_mse(missing_df, x, y, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_unsystematic_mse_vec(missing_df$y, missing_df$x, na_rm = FALSE),
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_unsystematic_mse_vec(missing_df$x, missing_df$y, na_rm = FALSE),
     NA_real_
   )
 
-  # Edge condition tests: Zero-length data:
+})
+
+test_that("srr: ww_unsystematic_mse errors on zero-length data", {
+
   expect_snapshot(
     ww_unsystematic_mse_vec(numeric(), numeric()),
     error = TRUE
   )
 
   empty_df <- tibble::tibble(x = numeric(), y = numeric())
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_unsystematic_mse(empty_df, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_unsystematic_mse(empty_df, y, x),
     error = TRUE
   )
+})
 
-  # Edge condition tests: All-NA:
+test_that("srr: ww_unsystematic_mse errors on all-NA data", {
+
   expect_snapshot(
     ww_unsystematic_mse_vec(rep(NA_real_, 4), 4:1),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_unsystematic_mse_vec(1:4, rep(NA_real_, 4)),
     error = TRUE
   )
 
   all_na <- tibble::tibble(x = rep(NA_real_, 4), y = 1:4)
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_unsystematic_mse(all_na, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_unsystematic_mse(all_na, y, x),
     error = TRUE
   )
 
-  # Edge condition tests: All-identical:
+  expect_snapshot(
+    ww_unsystematic_mse_vec(1:4, 1:4)
+  )
+
+})
+
+
+test_that("srr: ww_unsystematic_mse works with all identical data", {
+
+  all_identical <- tibble::tibble(x = 1:4, y = 1:4)
+  expect_snapshot(
+    ww_unsystematic_mse(all_identical, x, y)
+  )
+
   expect_snapshot(
     ww_unsystematic_mse_vec(1:4, 1:4)
   )
 
   all_identical <- tibble::tibble(x = 1:4, y = 1:4)
-  # Edge condition tests: All-identical:
   expect_snapshot(
     ww_unsystematic_mse(all_identical, x, y)
   )
+
 })
 
-test_that("other generic srr standards", {
+test_that("srr: ww_unsystematic_mse results don't change with trivial noise", {
   skip_if_not_installed("withr")
   x <- c(6, 8, 9, 10, 11, 14)
   y <- c(2, 3, 5, 5, 6, 8)
@@ -189,31 +185,34 @@ test_that("other generic srr standards", {
   noised_x <- x + rnorm(x, .Machine$double.eps, .Machine$double.eps)
   noised_df <- tibble::tibble(x = noised_x, y = y)
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_unsystematic_mse(noised_df, x, y),
     ww_unsystematic_mse(df, x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_unsystematic_mse(noised_df, y, x),
     ww_unsystematic_mse(df, y, x)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_unsystematic_mse_vec(noised_x, y),
     ww_unsystematic_mse_vec(x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_unsystematic_mse_vec(y, noised_x),
     ww_unsystematic_mse_vec(y, x)
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
+})
+
+test_that("srr: ww_unsystematic_mse results don't change with different seeds", {
+  skip_if_not_installed("withr")
+  x <- c(6, 8, 9, 10, 11, 14)
+  y <- c(2, 3, 5, 5, 6, 8)
+  df <- tibble::tibble(x = x, y = y)
+
   expect_equal(
     withr::with_seed(
       123,
@@ -225,7 +224,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -237,7 +235,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -249,7 +246,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -260,4 +256,5 @@ test_that("other generic srr standards", {
       ww_unsystematic_mse_vec(y, x)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_unsystematic_mse.R
+++ b/tests/testthat/test-srr-ww_unsystematic_mse.R
@@ -50,19 +50,6 @@ test_that("srr: ww_unsystematic_mse errors if truth and estimate are list column
   )
 })
 
-test_that("srr: ww_unsystematic_mse errors if truth and estimate are list columns", {
-  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  expect_snapshot(
-    ww_unsystematic_mse(list_df, x, y),
-    error = TRUE
-  )
-
-  expect_snapshot(
-    ww_unsystematic_mse(list_df, y, x),
-    error = TRUE
-  )
-})
-
 test_that("srr: ww_unsystematic_mse removes NaN and NA when na_rm = TRUE", {
 
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))

--- a/tests/testthat/test-srr-ww_unsystematic_rmpd.R
+++ b/tests/testthat/test-srr-ww_unsystematic_rmpd.R
@@ -50,19 +50,6 @@ test_that("srr: ww_unsystematic_rmpd errors if truth and estimate are list colum
   )
 })
 
-test_that("srr: ww_unsystematic_rmpd errors if truth and estimate are list columns", {
-  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  expect_snapshot(
-    ww_unsystematic_rmpd(list_df, x, y),
-    error = TRUE
-  )
-
-  expect_snapshot(
-    ww_unsystematic_rmpd(list_df, y, x),
-    error = TRUE
-  )
-})
-
 test_that("srr: ww_unsystematic_rmpd removes NaN and NA when na_rm = TRUE", {
 
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))

--- a/tests/testthat/test-srr-ww_unsystematic_rmpd.R
+++ b/tests/testthat/test-srr-ww_unsystematic_rmpd.R
@@ -1,187 +1,183 @@
 # This file was generated, do not edit by hand
 # Please edit inst/srr_template_nonspatial_yardstick.R instead
 
-test_that("srr: expected failures for ww_unsystematic_rmpd", {
+test_that("srr: ww_unsystematic_rmpd errors if truth and estimate are different lengths", {
   # Note that this test isn't applicable to data-frame input, which enforces
   # constant column lengths
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_unsystematic_rmpd_vec(1:5, 1:4),
     error = TRUE
   )
-
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_unsystematic_rmpd_vec(1:4, 1:5),
     error = TRUE
   )
+})
 
+test_that("srr: ww_unsystematic_rmpd errors if truth and estimate aren't numeric", {
   char_df <- tibble::tibble(x = 1:5, y = letters[1:5])
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_unsystematic_rmpd(char_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_unsystematic_rmpd(char_df, y, x),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_unsystematic_rmpd_vec(as.character(1:5), 1:4),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_unsystematic_rmpd_vec(1:5, as.character(1:4)),
     error = TRUE
   )
+})
 
+test_that("srr: ww_unsystematic_rmpd errors if truth and estimate are list columns", {
   list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_unsystematic_rmpd(list_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_unsystematic_rmpd(list_df, y, x),
     error = TRUE
   )
+})
 
-  #' @srrstats {G2.13} Missing data is properly handled
-  #' @srrstats {G2.15} Missingness is checked
-  #' @srrstats {G2.14} Users can specify behavior with NA results
-  #' @srrstats {G2.16} NaN is properly handled
+test_that("srr: ww_unsystematic_rmpd errors if truth and estimate are list columns", {
+  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
+  expect_snapshot(
+    ww_unsystematic_rmpd(list_df, x, y),
+    error = TRUE
+  )
+
+  expect_snapshot(
+    ww_unsystematic_rmpd(list_df, y, x),
+    error = TRUE
+  )
+})
+
+test_that("srr: ww_unsystematic_rmpd removes NaN and NA when na_rm = TRUE", {
+
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
-  #' Users can remove NA:
+
   expect_snapshot(
     round(ww_unsystematic_rmpd(missing_df, x, y)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_unsystematic_rmpd(missing_df, y, x)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_unsystematic_rmpd_vec(missing_df$y, missing_df$x), 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_unsystematic_rmpd_vec(missing_df$x, missing_df$y), 15),
   )
+})
 
-  #' @srrstats {G2.14b} Users can ignore NA:
+test_that("srr: ww_unsystematic_rmpd returns NA when na_rm = FALSE and NA is present", {
+
+  missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
+
   expect_identical(
     ww_unsystematic_rmpd(missing_df, y, x, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_unsystematic_rmpd(missing_df, x, y, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_unsystematic_rmpd_vec(missing_df$y, missing_df$x, na_rm = FALSE),
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_unsystematic_rmpd_vec(missing_df$x, missing_df$y, na_rm = FALSE),
     NA_real_
   )
 
-  # Edge condition tests: Zero-length data:
+})
+
+test_that("srr: ww_unsystematic_rmpd errors on zero-length data", {
+
   expect_snapshot(
     ww_unsystematic_rmpd_vec(numeric(), numeric()),
     error = TRUE
   )
 
   empty_df <- tibble::tibble(x = numeric(), y = numeric())
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_unsystematic_rmpd(empty_df, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_unsystematic_rmpd(empty_df, y, x),
     error = TRUE
   )
+})
 
-  # Edge condition tests: All-NA:
+test_that("srr: ww_unsystematic_rmpd errors on all-NA data", {
+
   expect_snapshot(
     ww_unsystematic_rmpd_vec(rep(NA_real_, 4), 4:1),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_unsystematic_rmpd_vec(1:4, rep(NA_real_, 4)),
     error = TRUE
   )
 
   all_na <- tibble::tibble(x = rep(NA_real_, 4), y = 1:4)
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_unsystematic_rmpd(all_na, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_unsystematic_rmpd(all_na, y, x),
     error = TRUE
   )
 
-  # Edge condition tests: All-identical:
+  expect_snapshot(
+    ww_unsystematic_rmpd_vec(1:4, 1:4)
+  )
+
+})
+
+
+test_that("srr: ww_unsystematic_rmpd works with all identical data", {
+
+  all_identical <- tibble::tibble(x = 1:4, y = 1:4)
+  expect_snapshot(
+    ww_unsystematic_rmpd(all_identical, x, y)
+  )
+
   expect_snapshot(
     ww_unsystematic_rmpd_vec(1:4, 1:4)
   )
 
   all_identical <- tibble::tibble(x = 1:4, y = 1:4)
-  # Edge condition tests: All-identical:
   expect_snapshot(
     ww_unsystematic_rmpd(all_identical, x, y)
   )
+
 })
 
-test_that("other generic srr standards", {
+test_that("srr: ww_unsystematic_rmpd results don't change with trivial noise", {
   skip_if_not_installed("withr")
   x <- c(6, 8, 9, 10, 11, 14)
   y <- c(2, 3, 5, 5, 6, 8)
@@ -189,31 +185,34 @@ test_that("other generic srr standards", {
   noised_x <- x + rnorm(x, .Machine$double.eps, .Machine$double.eps)
   noised_df <- tibble::tibble(x = noised_x, y = y)
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_unsystematic_rmpd(noised_df, x, y),
     ww_unsystematic_rmpd(df, x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_unsystematic_rmpd(noised_df, y, x),
     ww_unsystematic_rmpd(df, y, x)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_unsystematic_rmpd_vec(noised_x, y),
     ww_unsystematic_rmpd_vec(x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_unsystematic_rmpd_vec(y, noised_x),
     ww_unsystematic_rmpd_vec(y, x)
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
+})
+
+test_that("srr: ww_unsystematic_rmpd results don't change with different seeds", {
+  skip_if_not_installed("withr")
+  x <- c(6, 8, 9, 10, 11, 14)
+  y <- c(2, 3, 5, 5, 6, 8)
+  df <- tibble::tibble(x = x, y = y)
+
   expect_equal(
     withr::with_seed(
       123,
@@ -225,7 +224,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -237,7 +235,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -249,7 +246,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -260,4 +256,5 @@ test_that("other generic srr standards", {
       ww_unsystematic_rmpd_vec(y, x)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_unsystematic_rmse.R
+++ b/tests/testthat/test-srr-ww_unsystematic_rmse.R
@@ -50,19 +50,6 @@ test_that("srr: ww_unsystematic_rmse errors if truth and estimate are list colum
   )
 })
 
-test_that("srr: ww_unsystematic_rmse errors if truth and estimate are list columns", {
-  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  expect_snapshot(
-    ww_unsystematic_rmse(list_df, x, y),
-    error = TRUE
-  )
-
-  expect_snapshot(
-    ww_unsystematic_rmse(list_df, y, x),
-    error = TRUE
-  )
-})
-
 test_that("srr: ww_unsystematic_rmse removes NaN and NA when na_rm = TRUE", {
 
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))

--- a/tests/testthat/test-srr-ww_unsystematic_rmse.R
+++ b/tests/testthat/test-srr-ww_unsystematic_rmse.R
@@ -1,187 +1,183 @@
 # This file was generated, do not edit by hand
 # Please edit inst/srr_template_nonspatial_yardstick.R instead
 
-test_that("srr: expected failures for ww_unsystematic_rmse", {
+test_that("srr: ww_unsystematic_rmse errors if truth and estimate are different lengths", {
   # Note that this test isn't applicable to data-frame input, which enforces
   # constant column lengths
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_unsystematic_rmse_vec(1:5, 1:4),
     error = TRUE
   )
-
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_unsystematic_rmse_vec(1:4, 1:5),
     error = TRUE
   )
+})
 
+test_that("srr: ww_unsystematic_rmse errors if truth and estimate aren't numeric", {
   char_df <- tibble::tibble(x = 1:5, y = letters[1:5])
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_unsystematic_rmse(char_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_unsystematic_rmse(char_df, y, x),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_unsystematic_rmse_vec(as.character(1:5), 1:4),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_unsystematic_rmse_vec(1:5, as.character(1:4)),
     error = TRUE
   )
+})
 
+test_that("srr: ww_unsystematic_rmse errors if truth and estimate are list columns", {
   list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_unsystematic_rmse(list_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_unsystematic_rmse(list_df, y, x),
     error = TRUE
   )
+})
 
-  #' @srrstats {G2.13} Missing data is properly handled
-  #' @srrstats {G2.15} Missingness is checked
-  #' @srrstats {G2.14} Users can specify behavior with NA results
-  #' @srrstats {G2.16} NaN is properly handled
+test_that("srr: ww_unsystematic_rmse errors if truth and estimate are list columns", {
+  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
+  expect_snapshot(
+    ww_unsystematic_rmse(list_df, x, y),
+    error = TRUE
+  )
+
+  expect_snapshot(
+    ww_unsystematic_rmse(list_df, y, x),
+    error = TRUE
+  )
+})
+
+test_that("srr: ww_unsystematic_rmse removes NaN and NA when na_rm = TRUE", {
+
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
-  #' Users can remove NA:
+
   expect_snapshot(
     round(ww_unsystematic_rmse(missing_df, x, y)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_unsystematic_rmse(missing_df, y, x)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_unsystematic_rmse_vec(missing_df$y, missing_df$x), 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_unsystematic_rmse_vec(missing_df$x, missing_df$y), 15),
   )
+})
 
-  #' @srrstats {G2.14b} Users can ignore NA:
+test_that("srr: ww_unsystematic_rmse returns NA when na_rm = FALSE and NA is present", {
+
+  missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
+
   expect_identical(
     ww_unsystematic_rmse(missing_df, y, x, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_unsystematic_rmse(missing_df, x, y, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_unsystematic_rmse_vec(missing_df$y, missing_df$x, na_rm = FALSE),
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_unsystematic_rmse_vec(missing_df$x, missing_df$y, na_rm = FALSE),
     NA_real_
   )
 
-  # Edge condition tests: Zero-length data:
+})
+
+test_that("srr: ww_unsystematic_rmse errors on zero-length data", {
+
   expect_snapshot(
     ww_unsystematic_rmse_vec(numeric(), numeric()),
     error = TRUE
   )
 
   empty_df <- tibble::tibble(x = numeric(), y = numeric())
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_unsystematic_rmse(empty_df, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_unsystematic_rmse(empty_df, y, x),
     error = TRUE
   )
+})
 
-  # Edge condition tests: All-NA:
+test_that("srr: ww_unsystematic_rmse errors on all-NA data", {
+
   expect_snapshot(
     ww_unsystematic_rmse_vec(rep(NA_real_, 4), 4:1),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_unsystematic_rmse_vec(1:4, rep(NA_real_, 4)),
     error = TRUE
   )
 
   all_na <- tibble::tibble(x = rep(NA_real_, 4), y = 1:4)
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_unsystematic_rmse(all_na, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_unsystematic_rmse(all_na, y, x),
     error = TRUE
   )
 
-  # Edge condition tests: All-identical:
+  expect_snapshot(
+    ww_unsystematic_rmse_vec(1:4, 1:4)
+  )
+
+})
+
+
+test_that("srr: ww_unsystematic_rmse works with all identical data", {
+
+  all_identical <- tibble::tibble(x = 1:4, y = 1:4)
+  expect_snapshot(
+    ww_unsystematic_rmse(all_identical, x, y)
+  )
+
   expect_snapshot(
     ww_unsystematic_rmse_vec(1:4, 1:4)
   )
 
   all_identical <- tibble::tibble(x = 1:4, y = 1:4)
-  # Edge condition tests: All-identical:
   expect_snapshot(
     ww_unsystematic_rmse(all_identical, x, y)
   )
+
 })
 
-test_that("other generic srr standards", {
+test_that("srr: ww_unsystematic_rmse results don't change with trivial noise", {
   skip_if_not_installed("withr")
   x <- c(6, 8, 9, 10, 11, 14)
   y <- c(2, 3, 5, 5, 6, 8)
@@ -189,31 +185,34 @@ test_that("other generic srr standards", {
   noised_x <- x + rnorm(x, .Machine$double.eps, .Machine$double.eps)
   noised_df <- tibble::tibble(x = noised_x, y = y)
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_unsystematic_rmse(noised_df, x, y),
     ww_unsystematic_rmse(df, x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_unsystematic_rmse(noised_df, y, x),
     ww_unsystematic_rmse(df, y, x)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_unsystematic_rmse_vec(noised_x, y),
     ww_unsystematic_rmse_vec(x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_unsystematic_rmse_vec(y, noised_x),
     ww_unsystematic_rmse_vec(y, x)
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
+})
+
+test_that("srr: ww_unsystematic_rmse results don't change with different seeds", {
+  skip_if_not_installed("withr")
+  x <- c(6, 8, 9, 10, 11, 14)
+  y <- c(2, 3, 5, 5, 6, 8)
+  df <- tibble::tibble(x = x, y = y)
+
   expect_equal(
     withr::with_seed(
       123,
@@ -225,7 +224,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -237,7 +235,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -249,7 +246,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -260,4 +256,5 @@ test_that("other generic srr standards", {
       ww_unsystematic_rmse_vec(y, x)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_willmott_d.R
+++ b/tests/testthat/test-srr-ww_willmott_d.R
@@ -1,187 +1,183 @@
 # This file was generated, do not edit by hand
 # Please edit inst/srr_template_nonspatial_yardstick.R instead
 
-test_that("srr: expected failures for ww_willmott_d", {
+test_that("srr: ww_willmott_d errors if truth and estimate are different lengths", {
   # Note that this test isn't applicable to data-frame input, which enforces
   # constant column lengths
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_willmott_d_vec(1:5, 1:4),
     error = TRUE
   )
-
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_willmott_d_vec(1:4, 1:5),
     error = TRUE
   )
+})
 
+test_that("srr: ww_willmott_d errors if truth and estimate aren't numeric", {
   char_df <- tibble::tibble(x = 1:5, y = letters[1:5])
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_willmott_d(char_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_willmott_d(char_df, y, x),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_willmott_d_vec(as.character(1:5), 1:4),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_willmott_d_vec(1:5, as.character(1:4)),
     error = TRUE
   )
+})
 
+test_that("srr: ww_willmott_d errors if truth and estimate are list columns", {
   list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_willmott_d(list_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_willmott_d(list_df, y, x),
     error = TRUE
   )
+})
 
-  #' @srrstats {G2.13} Missing data is properly handled
-  #' @srrstats {G2.15} Missingness is checked
-  #' @srrstats {G2.14} Users can specify behavior with NA results
-  #' @srrstats {G2.16} NaN is properly handled
+test_that("srr: ww_willmott_d errors if truth and estimate are list columns", {
+  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
+  expect_snapshot(
+    ww_willmott_d(list_df, x, y),
+    error = TRUE
+  )
+
+  expect_snapshot(
+    ww_willmott_d(list_df, y, x),
+    error = TRUE
+  )
+})
+
+test_that("srr: ww_willmott_d removes NaN and NA when na_rm = TRUE", {
+
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
-  #' Users can remove NA:
+
   expect_snapshot(
     round(ww_willmott_d(missing_df, x, y)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_willmott_d(missing_df, y, x)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_willmott_d_vec(missing_df$y, missing_df$x), 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_willmott_d_vec(missing_df$x, missing_df$y), 15),
   )
+})
 
-  #' @srrstats {G2.14b} Users can ignore NA:
+test_that("srr: ww_willmott_d returns NA when na_rm = FALSE and NA is present", {
+
+  missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
+
   expect_identical(
     ww_willmott_d(missing_df, y, x, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_willmott_d(missing_df, x, y, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_willmott_d_vec(missing_df$y, missing_df$x, na_rm = FALSE),
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_willmott_d_vec(missing_df$x, missing_df$y, na_rm = FALSE),
     NA_real_
   )
 
-  # Edge condition tests: Zero-length data:
+})
+
+test_that("srr: ww_willmott_d errors on zero-length data", {
+
   expect_snapshot(
     ww_willmott_d_vec(numeric(), numeric()),
     error = TRUE
   )
 
   empty_df <- tibble::tibble(x = numeric(), y = numeric())
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_willmott_d(empty_df, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_willmott_d(empty_df, y, x),
     error = TRUE
   )
+})
 
-  # Edge condition tests: All-NA:
+test_that("srr: ww_willmott_d errors on all-NA data", {
+
   expect_snapshot(
     ww_willmott_d_vec(rep(NA_real_, 4), 4:1),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_willmott_d_vec(1:4, rep(NA_real_, 4)),
     error = TRUE
   )
 
   all_na <- tibble::tibble(x = rep(NA_real_, 4), y = 1:4)
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_willmott_d(all_na, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_willmott_d(all_na, y, x),
     error = TRUE
   )
 
-  # Edge condition tests: All-identical:
+  expect_snapshot(
+    ww_willmott_d_vec(1:4, 1:4)
+  )
+
+})
+
+
+test_that("srr: ww_willmott_d works with all identical data", {
+
+  all_identical <- tibble::tibble(x = 1:4, y = 1:4)
+  expect_snapshot(
+    ww_willmott_d(all_identical, x, y)
+  )
+
   expect_snapshot(
     ww_willmott_d_vec(1:4, 1:4)
   )
 
   all_identical <- tibble::tibble(x = 1:4, y = 1:4)
-  # Edge condition tests: All-identical:
   expect_snapshot(
     ww_willmott_d(all_identical, x, y)
   )
+
 })
 
-test_that("other generic srr standards", {
+test_that("srr: ww_willmott_d results don't change with trivial noise", {
   skip_if_not_installed("withr")
   x <- c(6, 8, 9, 10, 11, 14)
   y <- c(2, 3, 5, 5, 6, 8)
@@ -189,31 +185,34 @@ test_that("other generic srr standards", {
   noised_x <- x + rnorm(x, .Machine$double.eps, .Machine$double.eps)
   noised_df <- tibble::tibble(x = noised_x, y = y)
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_willmott_d(noised_df, x, y),
     ww_willmott_d(df, x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_willmott_d(noised_df, y, x),
     ww_willmott_d(df, y, x)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_willmott_d_vec(noised_x, y),
     ww_willmott_d_vec(x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_willmott_d_vec(y, noised_x),
     ww_willmott_d_vec(y, x)
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
+})
+
+test_that("srr: ww_willmott_d results don't change with different seeds", {
+  skip_if_not_installed("withr")
+  x <- c(6, 8, 9, 10, 11, 14)
+  y <- c(2, 3, 5, 5, 6, 8)
+  df <- tibble::tibble(x = x, y = y)
+
   expect_equal(
     withr::with_seed(
       123,
@@ -225,7 +224,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -237,7 +235,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -249,7 +246,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -260,4 +256,5 @@ test_that("other generic srr standards", {
       ww_willmott_d_vec(y, x)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_willmott_d.R
+++ b/tests/testthat/test-srr-ww_willmott_d.R
@@ -50,19 +50,6 @@ test_that("srr: ww_willmott_d errors if truth and estimate are list columns", {
   )
 })
 
-test_that("srr: ww_willmott_d errors if truth and estimate are list columns", {
-  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  expect_snapshot(
-    ww_willmott_d(list_df, x, y),
-    error = TRUE
-  )
-
-  expect_snapshot(
-    ww_willmott_d(list_df, y, x),
-    error = TRUE
-  )
-})
-
 test_that("srr: ww_willmott_d removes NaN and NA when na_rm = TRUE", {
 
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))

--- a/tests/testthat/test-srr-ww_willmott_d1.R
+++ b/tests/testthat/test-srr-ww_willmott_d1.R
@@ -1,187 +1,183 @@
 # This file was generated, do not edit by hand
 # Please edit inst/srr_template_nonspatial_yardstick.R instead
 
-test_that("srr: expected failures for ww_willmott_d1", {
+test_that("srr: ww_willmott_d1 errors if truth and estimate are different lengths", {
   # Note that this test isn't applicable to data-frame input, which enforces
   # constant column lengths
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_willmott_d1_vec(1:5, 1:4),
     error = TRUE
   )
-
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_willmott_d1_vec(1:4, 1:5),
     error = TRUE
   )
+})
 
+test_that("srr: ww_willmott_d1 errors if truth and estimate aren't numeric", {
   char_df <- tibble::tibble(x = 1:5, y = letters[1:5])
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_willmott_d1(char_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_willmott_d1(char_df, y, x),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_willmott_d1_vec(as.character(1:5), 1:4),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_willmott_d1_vec(1:5, as.character(1:4)),
     error = TRUE
   )
+})
 
+test_that("srr: ww_willmott_d1 errors if truth and estimate are list columns", {
   list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_willmott_d1(list_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_willmott_d1(list_df, y, x),
     error = TRUE
   )
+})
 
-  #' @srrstats {G2.13} Missing data is properly handled
-  #' @srrstats {G2.15} Missingness is checked
-  #' @srrstats {G2.14} Users can specify behavior with NA results
-  #' @srrstats {G2.16} NaN is properly handled
+test_that("srr: ww_willmott_d1 errors if truth and estimate are list columns", {
+  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
+  expect_snapshot(
+    ww_willmott_d1(list_df, x, y),
+    error = TRUE
+  )
+
+  expect_snapshot(
+    ww_willmott_d1(list_df, y, x),
+    error = TRUE
+  )
+})
+
+test_that("srr: ww_willmott_d1 removes NaN and NA when na_rm = TRUE", {
+
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
-  #' Users can remove NA:
+
   expect_snapshot(
     round(ww_willmott_d1(missing_df, x, y)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_willmott_d1(missing_df, y, x)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_willmott_d1_vec(missing_df$y, missing_df$x), 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_willmott_d1_vec(missing_df$x, missing_df$y), 15),
   )
+})
 
-  #' @srrstats {G2.14b} Users can ignore NA:
+test_that("srr: ww_willmott_d1 returns NA when na_rm = FALSE and NA is present", {
+
+  missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
+
   expect_identical(
     ww_willmott_d1(missing_df, y, x, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_willmott_d1(missing_df, x, y, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_willmott_d1_vec(missing_df$y, missing_df$x, na_rm = FALSE),
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_willmott_d1_vec(missing_df$x, missing_df$y, na_rm = FALSE),
     NA_real_
   )
 
-  # Edge condition tests: Zero-length data:
+})
+
+test_that("srr: ww_willmott_d1 errors on zero-length data", {
+
   expect_snapshot(
     ww_willmott_d1_vec(numeric(), numeric()),
     error = TRUE
   )
 
   empty_df <- tibble::tibble(x = numeric(), y = numeric())
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_willmott_d1(empty_df, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_willmott_d1(empty_df, y, x),
     error = TRUE
   )
+})
 
-  # Edge condition tests: All-NA:
+test_that("srr: ww_willmott_d1 errors on all-NA data", {
+
   expect_snapshot(
     ww_willmott_d1_vec(rep(NA_real_, 4), 4:1),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_willmott_d1_vec(1:4, rep(NA_real_, 4)),
     error = TRUE
   )
 
   all_na <- tibble::tibble(x = rep(NA_real_, 4), y = 1:4)
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_willmott_d1(all_na, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_willmott_d1(all_na, y, x),
     error = TRUE
   )
 
-  # Edge condition tests: All-identical:
+  expect_snapshot(
+    ww_willmott_d1_vec(1:4, 1:4)
+  )
+
+})
+
+
+test_that("srr: ww_willmott_d1 works with all identical data", {
+
+  all_identical <- tibble::tibble(x = 1:4, y = 1:4)
+  expect_snapshot(
+    ww_willmott_d1(all_identical, x, y)
+  )
+
   expect_snapshot(
     ww_willmott_d1_vec(1:4, 1:4)
   )
 
   all_identical <- tibble::tibble(x = 1:4, y = 1:4)
-  # Edge condition tests: All-identical:
   expect_snapshot(
     ww_willmott_d1(all_identical, x, y)
   )
+
 })
 
-test_that("other generic srr standards", {
+test_that("srr: ww_willmott_d1 results don't change with trivial noise", {
   skip_if_not_installed("withr")
   x <- c(6, 8, 9, 10, 11, 14)
   y <- c(2, 3, 5, 5, 6, 8)
@@ -189,31 +185,34 @@ test_that("other generic srr standards", {
   noised_x <- x + rnorm(x, .Machine$double.eps, .Machine$double.eps)
   noised_df <- tibble::tibble(x = noised_x, y = y)
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_willmott_d1(noised_df, x, y),
     ww_willmott_d1(df, x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_willmott_d1(noised_df, y, x),
     ww_willmott_d1(df, y, x)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_willmott_d1_vec(noised_x, y),
     ww_willmott_d1_vec(x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_willmott_d1_vec(y, noised_x),
     ww_willmott_d1_vec(y, x)
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
+})
+
+test_that("srr: ww_willmott_d1 results don't change with different seeds", {
+  skip_if_not_installed("withr")
+  x <- c(6, 8, 9, 10, 11, 14)
+  y <- c(2, 3, 5, 5, 6, 8)
+  df <- tibble::tibble(x = x, y = y)
+
   expect_equal(
     withr::with_seed(
       123,
@@ -225,7 +224,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -237,7 +235,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -249,7 +246,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -260,4 +256,5 @@ test_that("other generic srr standards", {
       ww_willmott_d1_vec(y, x)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_willmott_d1.R
+++ b/tests/testthat/test-srr-ww_willmott_d1.R
@@ -50,19 +50,6 @@ test_that("srr: ww_willmott_d1 errors if truth and estimate are list columns", {
   )
 })
 
-test_that("srr: ww_willmott_d1 errors if truth and estimate are list columns", {
-  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  expect_snapshot(
-    ww_willmott_d1(list_df, x, y),
-    error = TRUE
-  )
-
-  expect_snapshot(
-    ww_willmott_d1(list_df, y, x),
-    error = TRUE
-  )
-})
-
 test_that("srr: ww_willmott_d1 removes NaN and NA when na_rm = TRUE", {
 
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))

--- a/tests/testthat/test-srr-ww_willmott_dr.R
+++ b/tests/testthat/test-srr-ww_willmott_dr.R
@@ -1,187 +1,183 @@
 # This file was generated, do not edit by hand
 # Please edit inst/srr_template_nonspatial_yardstick.R instead
 
-test_that("srr: expected failures for ww_willmott_dr", {
+test_that("srr: ww_willmott_dr errors if truth and estimate are different lengths", {
   # Note that this test isn't applicable to data-frame input, which enforces
   # constant column lengths
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_willmott_dr_vec(1:5, 1:4),
     error = TRUE
   )
-
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G2.0} Truth and estimate are equal in length:
   expect_snapshot(
     ww_willmott_dr_vec(1:4, 1:5),
     error = TRUE
   )
+})
 
+test_that("srr: ww_willmott_dr errors if truth and estimate aren't numeric", {
   char_df <- tibble::tibble(x = 1:5, y = letters[1:5])
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_willmott_dr(char_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_willmott_dr(char_df, y, x),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_willmott_dr_vec(as.character(1:5), 1:4),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.1} Truth and estimate are numeric:
   expect_snapshot(
     ww_willmott_dr_vec(1:5, as.character(1:4)),
     error = TRUE
   )
+})
 
+test_that("srr: ww_willmott_dr errors if truth and estimate are list columns", {
   list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_willmott_dr(list_df, x, y),
     error = TRUE
   )
 
-  #' @srrstats {G5.2} Testing errors
-  #' @srrstats {G5.2b} Testing errors
-  #' @srrstats {G5.8b} Data of unsupported types
-  #' @srrstats {G2.12} List column inputs fail:
   expect_snapshot(
     ww_willmott_dr(list_df, y, x),
     error = TRUE
   )
+})
 
-  #' @srrstats {G2.13} Missing data is properly handled
-  #' @srrstats {G2.15} Missingness is checked
-  #' @srrstats {G2.14} Users can specify behavior with NA results
-  #' @srrstats {G2.16} NaN is properly handled
+test_that("srr: ww_willmott_dr errors if truth and estimate are list columns", {
+  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
+  expect_snapshot(
+    ww_willmott_dr(list_df, x, y),
+    error = TRUE
+  )
+
+  expect_snapshot(
+    ww_willmott_dr(list_df, y, x),
+    error = TRUE
+  )
+})
+
+test_that("srr: ww_willmott_dr removes NaN and NA when na_rm = TRUE", {
+
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
-  #' Users can remove NA:
+
   expect_snapshot(
     round(ww_willmott_dr(missing_df, x, y)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_willmott_dr(missing_df, y, x)$.estimate, 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_willmott_dr_vec(missing_df$y, missing_df$x), 15),
   )
 
-  #' Users can remove NA:
   expect_snapshot(
     round(ww_willmott_dr_vec(missing_df$x, missing_df$y), 15),
   )
+})
 
-  #' @srrstats {G2.14b} Users can ignore NA:
+test_that("srr: ww_willmott_dr returns NA when na_rm = FALSE and NA is present", {
+
+  missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))
+
   expect_identical(
     ww_willmott_dr(missing_df, y, x, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_willmott_dr(missing_df, x, y, na_rm = FALSE)$.estimate,
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_willmott_dr_vec(missing_df$y, missing_df$x, na_rm = FALSE),
     NA_real_
   )
 
-  #' @srrstats {G2.14b} Users can ignore NA:
   expect_identical(
     ww_willmott_dr_vec(missing_df$x, missing_df$y, na_rm = FALSE),
     NA_real_
   )
 
-  # Edge condition tests: Zero-length data:
+})
+
+test_that("srr: ww_willmott_dr errors on zero-length data", {
+
   expect_snapshot(
     ww_willmott_dr_vec(numeric(), numeric()),
     error = TRUE
   )
 
   empty_df <- tibble::tibble(x = numeric(), y = numeric())
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_willmott_dr(empty_df, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: Zero-length data:
   expect_snapshot(
     ww_willmott_dr(empty_df, y, x),
     error = TRUE
   )
+})
 
-  # Edge condition tests: All-NA:
+test_that("srr: ww_willmott_dr errors on all-NA data", {
+
   expect_snapshot(
     ww_willmott_dr_vec(rep(NA_real_, 4), 4:1),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_willmott_dr_vec(1:4, rep(NA_real_, 4)),
     error = TRUE
   )
 
   all_na <- tibble::tibble(x = rep(NA_real_, 4), y = 1:4)
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_willmott_dr(all_na, x, y),
     error = TRUE
   )
 
-  # Edge condition tests: All-NA:
   expect_snapshot(
     ww_willmott_dr(all_na, y, x),
     error = TRUE
   )
 
-  # Edge condition tests: All-identical:
+  expect_snapshot(
+    ww_willmott_dr_vec(1:4, 1:4)
+  )
+
+})
+
+
+test_that("srr: ww_willmott_dr works with all identical data", {
+
+  all_identical <- tibble::tibble(x = 1:4, y = 1:4)
+  expect_snapshot(
+    ww_willmott_dr(all_identical, x, y)
+  )
+
   expect_snapshot(
     ww_willmott_dr_vec(1:4, 1:4)
   )
 
   all_identical <- tibble::tibble(x = 1:4, y = 1:4)
-  # Edge condition tests: All-identical:
   expect_snapshot(
     ww_willmott_dr(all_identical, x, y)
   )
+
 })
 
-test_that("other generic srr standards", {
+test_that("srr: ww_willmott_dr results don't change with trivial noise", {
   skip_if_not_installed("withr")
   x <- c(6, 8, 9, 10, 11, 14)
   y <- c(2, 3, 5, 5, 6, 8)
@@ -189,31 +185,34 @@ test_that("other generic srr standards", {
   noised_x <- x + rnorm(x, .Machine$double.eps, .Machine$double.eps)
   noised_df <- tibble::tibble(x = noised_x, y = y)
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_willmott_dr(noised_df, x, y),
     ww_willmott_dr(df, x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_willmott_dr(noised_df, y, x),
     ww_willmott_dr(df, y, x)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_willmott_dr_vec(noised_x, y),
     ww_willmott_dr_vec(x, y)
   )
 
-  # Noise susceptibility tests: Trivial noise doesn't change results:
   expect_equal(
     ww_willmott_dr_vec(y, noised_x),
     ww_willmott_dr_vec(y, x)
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
+})
+
+test_that("srr: ww_willmott_dr results don't change with different seeds", {
+  skip_if_not_installed("withr")
+  x <- c(6, 8, 9, 10, 11, 14)
+  y <- c(2, 3, 5, 5, 6, 8)
+  df <- tibble::tibble(x = x, y = y)
+
   expect_equal(
     withr::with_seed(
       123,
@@ -225,7 +224,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -237,7 +235,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -249,7 +246,6 @@ test_that("other generic srr standards", {
     )
   )
 
-  # Noise susceptibility tests: Different seeds are equivalent:
   expect_equal(
     withr::with_seed(
       123,
@@ -260,4 +256,5 @@ test_that("other generic srr standards", {
       ww_willmott_dr_vec(y, x)
     )
   )
+
 })

--- a/tests/testthat/test-srr-ww_willmott_dr.R
+++ b/tests/testthat/test-srr-ww_willmott_dr.R
@@ -50,19 +50,6 @@ test_that("srr: ww_willmott_dr errors if truth and estimate are list columns", {
   )
 })
 
-test_that("srr: ww_willmott_dr errors if truth and estimate are list columns", {
-  list_df <- tibble::tibble(x = 1:5, y = lapply(1:5, function(x) x))
-  expect_snapshot(
-    ww_willmott_dr(list_df, x, y),
-    error = TRUE
-  )
-
-  expect_snapshot(
-    ww_willmott_dr(list_df, y, x),
-    error = TRUE
-  )
-})
-
 test_that("srr: ww_willmott_dr removes NaN and NA when na_rm = TRUE", {
 
   missing_df <- tibble::tibble(x = c(NaN, 2:5), y = c(1:4, NA))


### PR DESCRIPTION
Addresses #20 by factoring out the non-spatial srr tests into more calls to test_that(), making it a bit easier to remember what each test is actually testing.
